### PR TITLE
feat: change default precisions and make them configurable

### DIFF
--- a/custom_components/ferroamp/config_flow.py
+++ b/custom_components/ferroamp/config_flow.py
@@ -7,7 +7,16 @@ from homeassistant.const import CONF_NAME, CONF_PREFIX
 from homeassistant.core import callback
 from homeassistant.util import slugify
 
-from .const import CONF_INTERVAL, DOMAIN, MANUFACTURER
+from .const import (
+    CONF_INTERVAL,
+    CONF_PRECISION_BATTERY,
+    CONF_PRECISION_CURRENT,
+    CONF_PRECISION_ENERGY,
+    CONF_PRECISION_TEMPERATURE,
+    CONF_PRECISION_VOLTAGE,
+    DOMAIN,
+    MANUFACTURER
+)
 
 TOPIC_SCHEMA = vol.Schema({
     vol.Required(CONF_NAME, default=MANUFACTURER): cv.string,
@@ -56,6 +65,26 @@ class FerroampOptionsFlowHandler(config_entries.OptionsFlow):
         if interval is None or interval == 0:
             interval = 30
 
+        precision_battery = self.config_entry.options.get(CONF_PRECISION_BATTERY)
+        if precision_battery is None:
+            precision_battery = 1
+
+        precision_current = self.config_entry.options.get(CONF_PRECISION_CURRENT)
+        if precision_current is None:
+            precision_current = 0
+
+        precision_energy = self.config_entry.options.get(CONF_PRECISION_ENERGY)
+        if precision_energy is None:
+            precision_energy = 1
+
+        precision_temperature = self.config_entry.options.get(CONF_PRECISION_TEMPERATURE)
+        if precision_temperature is None:
+            precision_temperature = 0
+
+        precision_voltage = self.config_entry.options.get(CONF_PRECISION_VOLTAGE)
+        if precision_voltage is None:
+            precision_voltage = 0
+
         return self.async_show_form(
             step_id="init",
             data_schema=vol.Schema(
@@ -63,6 +92,26 @@ class FerroampOptionsFlowHandler(config_entries.OptionsFlow):
                     vol.Required(
                         CONF_INTERVAL,
                         default=interval,
+                    ): cv.positive_int,
+                    vol.Required(
+                        CONF_PRECISION_BATTERY,
+                        default=precision_battery,
+                    ): cv.positive_int,
+                    vol.Required(
+                        CONF_PRECISION_CURRENT,
+                        default=precision_current,
+                    ): cv.positive_int,
+                    vol.Required(
+                        CONF_PRECISION_ENERGY,
+                        default=precision_energy,
+                    ): cv.positive_int,
+                    vol.Required(
+                        CONF_PRECISION_TEMPERATURE,
+                        default=precision_temperature,
+                    ): cv.positive_int,
+                    vol.Required(
+                        CONF_PRECISION_VOLTAGE,
+                        default=precision_voltage,
                     ): cv.positive_int
                 }
             ),

--- a/custom_components/ferroamp/const.py
+++ b/custom_components/ferroamp/const.py
@@ -1,6 +1,11 @@
 """Constants for Ferroamp"""
 
 CONF_INTERVAL = "interval"
+CONF_PRECISION_BATTERY = "precision_battery"
+CONF_PRECISION_CURRENT = "precision_current"
+CONF_PRECISION_ENERGY = "precision_energy"
+CONF_PRECISION_TEMPERATURE = "precision_temperature"
+CONF_PRECISION_VOLTAGE = "precision_voltage"
 DATA_DEVICES = "devices"
 DATA_LISTENERS = "listeners"
 DATA_PREFIXES = "prefixes"

--- a/custom_components/ferroamp/sensor.py
+++ b/custom_components/ferroamp/sensor.py
@@ -22,7 +22,18 @@ from homeassistant.core import callback
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.util import slugify
 
-from .const import CONF_INTERVAL, DATA_DEVICES, DATA_LISTENERS, DOMAIN, MANUFACTURER
+from .const import (
+    CONF_INTERVAL,
+    CONF_PRECISION_BATTERY,
+    CONF_PRECISION_CURRENT,
+    CONF_PRECISION_ENERGY,
+    CONF_PRECISION_TEMPERATURE,
+    CONF_PRECISION_VOLTAGE,
+    DATA_DEVICES,
+    DATA_LISTENERS,
+    DOMAIN,
+    MANUFACTURER
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -59,9 +70,29 @@ async def async_setup_entry(
     if interval is None or interval == 0:
         interval = 30
 
+    precision_battery = config_entry.options.get(CONF_PRECISION_BATTERY)
+    if precision_battery is None:
+        precision_battery = 1
+
+    precision_current = config_entry.options.get(CONF_PRECISION_CURRENT)
+    if precision_current is None:
+        precision_current = 0
+
+    precision_energy = config_entry.options.get(CONF_PRECISION_ENERGY)
+    if precision_energy is None:
+        precision_energy = 1
+
+    precision_temperature = config_entry.options.get(CONF_PRECISION_TEMPERATURE)
+    if precision_temperature is None:
+        precision_temperature = 0
+
+    precision_voltage = config_entry.options.get(CONF_PRECISION_VOLTAGE)
+    if precision_voltage is None:
+        precision_voltage = 0
+
     listeners.append(config_entry.add_update_listener(options_update_listener))
 
-    ehub = ehub_sensors(slug, name, interval, config_id)
+    ehub = ehub_sensors(slug, name, interval, precision_battery, precision_energy, config_id)
     eso_sensors = {}
     esm_sensors = {}
     sso_sensors = {}
@@ -97,27 +128,27 @@ async def async_setup_entry(
         if store is None:
             store = config[device_id] = {}
             sensors = sso_sensors[sso_id] = [
-                IntValFerroampSensor(
+                VoltageFerroampSensor(
                     f"{device_name} PV String Voltage",
                     "upv",
-                    VOLT,
                     "mdi:current-dc",
                     device_id,
                     device_name,
                     interval,
+                    precision_voltage,
                     config_id,
                 ),
-                FloatValFerroampSensor(
+                CurrentFerroampSensor(
                     f"{device_name} PV String Current",
                     "ipv",
-                    ELECTRICAL_CURRENT_AMPERE,
                     "mdi:current-dc",
                     device_id,
                     device_name,
                     interval,
-                    config_id,
+                    precision_current,
+                    config_id
                 ),
-                PowerFerroampSensor(
+                CalculatedPowerFerroampSensor(
                     f"{device_name} PV String Power",
                     "upv",
                     "ipv",
@@ -134,6 +165,7 @@ async def async_setup_entry(
                     device_id,
                     device_name,
                     interval,
+                    precision_energy,
                     config_id,
                 ),
                 StringValFerroampSensor(
@@ -154,15 +186,14 @@ async def async_setup_entry(
                     interval,
                     config_id,
                 ),
-                FloatValFerroampSensor(
+                TemperatureFerroampSensor(
                     f"{device_name} PCB Temperature",
                     "temp",
-                    TEMP_CELSIUS,
-                    "mdi:thermometer",
                     device_id,
                     device_name,
                     interval,
-                    config_id,
+                    precision_temperature,
+                    config_id
                 ),
             ]
 
@@ -181,27 +212,27 @@ async def async_setup_entry(
         if store is None:
             store = config[device_id] = {}
             sensors = eso_sensors[eso_id] = [
-                IntValFerroampSensor(
+                VoltageFerroampSensor(
                     f"{device_name} Battery Voltage",
                     "ubat",
-                    VOLT,
                     "mdi:battery",
                     device_id,
                     device_name,
                     interval,
+                    precision_voltage,
                     config_id,
                 ),
-                FloatValFerroampSensor(
+                CurrentFerroampSensor(
                     f"{device_name} Battery Current",
                     "ibat",
-                    ELECTRICAL_CURRENT_AMPERE,
                     "mdi:battery",
                     device_id,
                     device_name,
                     interval,
-                    config_id,
+                    precision_current,
+                    config_id
                 ),
-                PowerFerroampSensor(
+                CalculatedPowerFerroampSensor(
                     f"{device_name} Battery Power",
                     "ubat",
                     "ibat",
@@ -218,6 +249,7 @@ async def async_setup_entry(
                     device_id,
                     device_name,
                     interval,
+                    precision_energy,
                     config_id,
                 ),
                 EnergyFerroampSensor(
@@ -227,6 +259,7 @@ async def async_setup_entry(
                     device_id,
                     device_name,
                     interval,
+                    precision_energy,
                     config_id,
                 ),
                 BatteryFerroampSensor(
@@ -235,6 +268,7 @@ async def async_setup_entry(
                     device_id,
                     device_name,
                     interval,
+                    precision_battery,
                     config_id,
                 ),
                 StringValFerroampSensor(
@@ -255,15 +289,14 @@ async def async_setup_entry(
                     interval,
                     config_id,
                 ),
-                FloatValFerroampSensor(
+                TemperatureFerroampSensor(
                     f"{device_name} PCB Temperature",
                     "temp",
-                    TEMP_CELSIUS,
-                    "mdi:thermometer",
                     device_id,
                     device_name,
                     interval,
-                    config_id,
+                    precision_temperature,
+                    config_id
                 ),
             ]
 
@@ -286,6 +319,7 @@ async def async_setup_entry(
                     device_id,
                     device_name,
                     interval,
+                    precision_battery,
                     config_id,
                 ),
                 BatteryFerroampSensor(
@@ -294,6 +328,7 @@ async def async_setup_entry(
                     device_id,
                     device_name,
                     interval,
+                    precision_battery,
                     config_id,
                 ),
                 IntValFerroampSensor(
@@ -331,7 +366,7 @@ async def options_update_listener(hass, entry):
     config = hass.data[DOMAIN][DATA_DEVICES][entry.unique_id]
     for device in config.values():
         for sensor in device.values():
-            sensor.set_interval(entry.options.get(CONF_INTERVAL))
+            sensor.handle_options_update(entry.options)
 
 
 class FerroampSensor(RestoreEntity):
@@ -346,7 +381,7 @@ class FerroampSensor(RestoreEntity):
         self._icon = icon
         self._device_id = device_id
         self._device_name = device_name
-        self.interval = interval
+        self._interval = interval
         self.config_id = config_id
         self.updated = datetime.min
         self.event = {}
@@ -386,7 +421,7 @@ class FerroampSensor(RestoreEntity):
         self.event.update(event)
         now = datetime.now()
         delta = (now - self.updated).total_seconds()
-        if delta > self.interval and self.entity_id is not None:
+        if delta > self._interval and self.entity_id is not None:
             self.process_events(now)
 
     def process_events(self, now):
@@ -427,8 +462,8 @@ class FerroampSensor(RestoreEntity):
         self.hass.data[DOMAIN][DATA_DEVICES][self.config_id][self.device_id][self.unique_id] = self
         self.process_events(datetime.now())
 
-    def set_interval(self, interval):
-        self.interval = interval
+    def handle_options_update(self, options):
+        self._interval = options.get(CONF_INTERVAL)
 
 
 class IntValFerroampSensor(FerroampSensor):
@@ -471,9 +506,10 @@ class StringValFerroampSensor(FerroampSensor):
 class FloatValFerroampSensor(FerroampSensor):
     """Representation of a Ferroamp float value Sensor."""
 
-    def __init__(self, name, key, unit, icon, device_id, device_name, interval, config_id):
+    def __init__(self, name, key, unit, icon, device_id, device_name, interval, precision, config_id):
         """Initialize the sensor."""
         super().__init__(name, key, unit, icon, device_id, device_name, interval, config_id)
+        self._precision = precision
 
     def update_state_from_events(self, events):
         temp = 0
@@ -483,7 +519,9 @@ class FloatValFerroampSensor(FerroampSensor):
             v = event.get(self._state_key, None)
             if v is not None:
                 temp += float(v["val"])
-        self._state = round(temp / len(events), 2)
+        self._state = round(temp / len(events), self._precision)
+        if self._precision == 0:
+            self._state = int(self._state)
 
 
 class DcLinkFerroampSensor(FerroampSensor):
@@ -512,10 +550,10 @@ class DcLinkFerroampSensor(FerroampSensor):
         self.attrs = dict(neg=round(float(neg / len(events)), 2), pos=round(float(pos / len(events)), 2))
 
 
-class BatteryFerroampSensor(IntValFerroampSensor):
-    def __init__(self, name, key, device_id, device_name, interval, config_id):
+class BatteryFerroampSensor(FloatValFerroampSensor):
+    def __init__(self, name, key, device_id, device_name, interval, precision, config_id):
         super().__init__(
-            name, key, PERCENTAGE, "mdi:battery-low", device_id, device_name, interval, config_id
+            name, key, PERCENTAGE, "mdi:battery-low", device_id, device_name, interval, precision, config_id
         )
 
     @property
@@ -530,13 +568,58 @@ class BatteryFerroampSensor(IntValFerroampSensor):
 
         return self._icon
 
+    def handle_options_update(self, options):
+        super().handle_options_update(options)
+        self._precision = options.get(CONF_PRECISION_BATTERY)
 
-class EnergyFerroampSensor(IntValFerroampSensor):
+
+class TemperatureFerroampSensor(FloatValFerroampSensor):
+    def __init__(self, name, key, device_id, device_name, interval, precision, config_id):
+        super().__init__(
+            name, key, TEMP_CELSIUS, "mdi:thermometer", device_id, device_name, interval, precision, config_id
+        )
+
+    def handle_options_update(self, options):
+        super().handle_options_update(options)
+        self._precision = options.get(CONF_PRECISION_TEMPERATURE)
+
+
+class CurrentFerroampSensor(FloatValFerroampSensor):
+    def __init__(self, name, key, icon, device_id, device_name, interval, precision, config_id):
+        super().__init__(
+            name,
+            key,
+            ELECTRICAL_CURRENT_AMPERE,
+            icon,
+            device_id,
+            device_name,
+            interval,
+            precision,
+            config_id
+        )
+
+    def handle_options_update(self, options):
+        super().handle_options_update(options)
+        self._precision = options.get(CONF_PRECISION_CURRENT)
+
+
+class VoltageFerroampSensor(FloatValFerroampSensor):
+    def __init__(self, name, key, icon, device_id, device_name, interval, precision, config_id):
+        super().__init__(
+            name, key, VOLT, icon, device_id, device_name, interval, precision, config_id
+        )
+
+    def handle_options_update(self, options):
+        super().handle_options_update(options)
+        self._precision = options.get(CONF_PRECISION_VOLTAGE)
+
+
+class EnergyFerroampSensor(FloatValFerroampSensor):
     """Representation of a Ferroamp energy in kWh value Sensor."""
 
-    def __init__(self, name, key, icon, device_id, device_name, interval, config_id):
+    def __init__(self, name, key, icon, device_id, device_name, interval, precision, config_id):
         """Initialize the sensor"""
-        super().__init__(name, key, ENERGY_KILO_WATT_HOUR, icon, device_id, device_name, interval, config_id)
+        super().__init__(name, key, ENERGY_KILO_WATT_HOUR, icon, device_id, device_name, interval, precision, config_id)
 
     def update_state_from_events(self, events):
         temp = 0
@@ -546,7 +629,13 @@ class EnergyFerroampSensor(IntValFerroampSensor):
             v = event.get(self._state_key, None)
             if v is not None:
                 temp += float(v["val"])
-        self._state = int(temp / len(events) / 3600000000)
+        self._state = round(temp / len(events) / 3600000000, self._precision)
+        if self._precision == 0:
+            self._state = int(self._state)
+
+    def handle_options_update(self, options):
+        super().handle_options_update(options)
+        self._precision = options.get(CONF_PRECISION_ENERGY)
 
 
 class RelayStatusFerroampSensor(FerroampSensor):
@@ -572,13 +661,27 @@ class RelayStatusFerroampSensor(FerroampSensor):
             self._state = temp
 
 
-class PowerFerroampSensor(FerroampSensor):
+class PowerFerroampSensor(FloatValFerroampSensor):
+    """Representation of a Ferroamp Power Sensor."""
+
+    def __init__(self, name, key, icon, device_id, device_name, interval, config_id):
+        super().__init__(name, key, POWER_WATT, icon, device_id, device_name, interval, 0, config_id)
+
+
+class CalculatedPowerFerroampSensor(FerroampSensor):
     """Representation of a Ferroamp Power Sensor based on V and A."""
 
     def __init__(self, name, voltage_key, current_key, icon, device_id, device_name, interval, config_id):
         """Initialize the sensor."""
         super().__init__(
-            name, voltage_key, POWER_KILO_WATT, icon, device_id, device_name, interval, config_id
+            name,
+            voltage_key,
+            POWER_KILO_WATT,
+            icon,
+            device_id,
+            device_name,
+            interval,
+            config_id
         )
         self._voltage_key = voltage_key
         self._current_key = current_key
@@ -599,15 +702,16 @@ class PowerFerroampSensor(FerroampSensor):
                 temp_voltage += float(voltage["val"])
                 temp_current += float(current["val"])
 
-        self._state = round(temp_voltage / len(events) * temp_current / len(events) / 1000, 2)
+        self._state = int(round(temp_voltage / len(events) * temp_current / len(events) / 1000, 0))
 
 
 class ThreePhaseFerroampSensor(FerroampSensor):
     """Representation of a Ferroamp ThreePhase Sensor."""
 
-    def __init__(self, name, key, unit, icon, device_id, device_name, interval, config_id):
+    def __init__(self, name, key, unit, icon, device_id, device_name, interval, precision, config_id):
         """Initialize the sensor."""
         super().__init__(name, key, unit, icon, device_id, device_name, interval, config_id)
+        self._precision = precision
 
     def get_phases(self, event):
         phases = event.get(self._state_key, None)
@@ -628,7 +732,9 @@ class ThreePhaseFerroampSensor(FerroampSensor):
                 l1 += phases["L1"]
                 l2 += phases["L2"]
                 l3 += phases["L3"]
-        self._state = int(l1 / len(events) + l2 / len(events) + l3 / len(events))
+        self._state = round(l1 / len(events) + l2 / len(events) + l3 / len(events), self._precision)
+        if self._precision == 0:
+            self._state = int(self._state)
         self.attrs = dict(
             L1=round(float(l1 / len(events)), 2),
             L2=round(float(l2 / len(events)), 2),
@@ -637,23 +743,33 @@ class ThreePhaseFerroampSensor(FerroampSensor):
 
 
 class ThreePhaseEnergyFerroampSensor(ThreePhaseFerroampSensor):
-    def __init__(self, name, key, icon, device_id, device_name, interval, config_id):
+    def __init__(self, name, key, icon, device_id, device_name, interval, precision, config_id):
         """Initialize the sensor."""
-        super().__init__(name, key, ENERGY_KILO_WATT_HOUR, icon, device_id, device_name, interval, config_id)
+        super().__init__(name, key, ENERGY_KILO_WATT_HOUR, icon, device_id, device_name, interval, precision, config_id)
 
     def get_phases(self, event):
         phases = super().get_phases(event)
         if phases is not None:
             phases = dict(
-                L1=int(phases["L1"] / 3600000000),
-                L2=int(phases["L2"] / 3600000000),
-                L3=int(phases["L3"] / 3600000000),
+                L1=round(phases["L1"] / 3600000000, 2),
+                L2=round(phases["L2"] / 3600000000, 2),
+                L3=round(phases["L3"] / 3600000000, 2),
             )
 
         return phases
 
+    def handle_options_update(self, options):
+        super().handle_options_update(options)
+        self._precision = options.get(CONF_PRECISION_ENERGY)
 
-def ehub_sensors(slug, name, interval, config_id):
+
+class ThreePhasePowerFerroampSensor(ThreePhaseFerroampSensor):
+    def __init__(self, name, key, icon, device_id, device_name, interval, config_id):
+        """Initialize the sensor."""
+        super().__init__(name, key, POWER_WATT, icon, device_id, device_name, interval, 0, config_id)
+
+
+def ehub_sensors(slug, name, interval, precision_battery, precision_energy, config_id):
     return [
         FloatValFerroampSensor(
             f"{name} Estimated Grid Frequency",
@@ -663,6 +779,7 @@ def ehub_sensors(slug, name, interval, config_id):
             f"{slug}_{EHUB}",
             f"{name} {EHUB_NAME}",
             interval,
+            2,
             config_id,
         ),
         ThreePhaseFerroampSensor(
@@ -673,6 +790,7 @@ def ehub_sensors(slug, name, interval, config_id):
             f"{slug}_{EHUB}",
             f"{name} {EHUB_NAME}",
             interval,
+            0,
             config_id,
         ),
         ThreePhaseFerroampSensor(
@@ -683,6 +801,7 @@ def ehub_sensors(slug, name, interval, config_id):
             f"{slug}_{EHUB}",
             f"{name} {EHUB_NAME}",
             interval,
+            0,
             config_id,
         ),
         ThreePhaseFerroampSensor(
@@ -693,6 +812,7 @@ def ehub_sensors(slug, name, interval, config_id):
             f"{slug}_{EHUB}",
             f"{name} {EHUB_NAME}",
             interval,
+            0,
             config_id,
         ),
         ThreePhaseFerroampSensor(
@@ -703,6 +823,7 @@ def ehub_sensors(slug, name, interval, config_id):
             f"{slug}_{EHUB}",
             f"{name} {EHUB_NAME}",
             interval,
+            0,
             config_id,
         ),
         ThreePhaseFerroampSensor(
@@ -713,6 +834,7 @@ def ehub_sensors(slug, name, interval, config_id):
             f"{slug}_{EHUB}",
             f"{name} {EHUB_NAME}",
             interval,
+            0,
             config_id,
         ),
         ThreePhaseFerroampSensor(
@@ -723,6 +845,7 @@ def ehub_sensors(slug, name, interval, config_id):
             f"{slug}_{EHUB}",
             f"{name} {EHUB_NAME}",
             interval,
+            0,
             config_id,
         ),
         ThreePhaseFerroampSensor(
@@ -733,62 +856,57 @@ def ehub_sensors(slug, name, interval, config_id):
             f"{slug}_{EHUB}",
             f"{name} {EHUB_NAME}",
             interval,
+            0,
             config_id,
         ),
-        ThreePhaseFerroampSensor(
+        ThreePhasePowerFerroampSensor(
             f"{name} Grid Power",
             "pext",
-            POWER_WATT,
             "mdi:transmission-tower",
             f"{slug}_{EHUB}",
             f"{name} {EHUB_NAME}",
             interval,
             config_id,
         ),
-        ThreePhaseFerroampSensor(
+        ThreePhasePowerFerroampSensor(
             f"{name} Grid Power Reactive",
             "pextreactive",
-            POWER_WATT,
             "mdi:transmission-tower",
             f"{slug}_{EHUB}",
             f"{name} {EHUB_NAME}",
             interval,
             config_id,
         ),
-        ThreePhaseFerroampSensor(
+        ThreePhasePowerFerroampSensor(
             f"{name} Inverter Power, active",
             "pinv",
-            POWER_WATT,
             "mdi:solar-power",
             f"{slug}_{EHUB}",
             f"{name} {EHUB_NAME}",
             interval,
             config_id,
         ),
-        ThreePhaseFerroampSensor(
+        ThreePhasePowerFerroampSensor(
             f"{name} Inverter Power, reactive",
             "pinvreactive",
-            POWER_WATT,
             "mdi:solar-power",
             f"{slug}_{EHUB}",
             f"{name} {EHUB_NAME}",
             interval,
             config_id,
         ),
-        ThreePhaseFerroampSensor(
+        ThreePhasePowerFerroampSensor(
             f"{name} Consumption Power",
             "pload",
-            POWER_WATT,
             "mdi:power-plug",
             f"{slug}_{EHUB}",
             f"{name} {EHUB_NAME}",
             interval,
             config_id,
         ),
-        ThreePhaseFerroampSensor(
+        ThreePhasePowerFerroampSensor(
             f"{name} Consumption Power Reactive",
             "ploadreactive",
-            POWER_WATT,
             "mdi:power-plug",
             f"{slug}_{EHUB}",
             f"{name} {EHUB_NAME}",
@@ -802,6 +920,7 @@ def ehub_sensors(slug, name, interval, config_id):
             f"{slug}_{EHUB}",
             f"{name} {EHUB_NAME}",
             interval,
+            precision_energy,
             config_id,
         ),
         ThreePhaseEnergyFerroampSensor(
@@ -811,6 +930,7 @@ def ehub_sensors(slug, name, interval, config_id):
             f"{slug}_{EHUB}",
             f"{name} {EHUB_NAME}",
             interval,
+            precision_energy,
             config_id,
         ),
         ThreePhaseEnergyFerroampSensor(
@@ -820,6 +940,7 @@ def ehub_sensors(slug, name, interval, config_id):
             f"{slug}_{EHUB}",
             f"{name} {EHUB_NAME}",
             interval,
+            precision_energy,
             config_id,
         ),
         ThreePhaseEnergyFerroampSensor(
@@ -829,6 +950,7 @@ def ehub_sensors(slug, name, interval, config_id):
             f"{slug}_{EHUB}",
             f"{name} {EHUB_NAME}",
             interval,
+            precision_energy,
             config_id,
         ),
         ThreePhaseEnergyFerroampSensor(
@@ -838,6 +960,7 @@ def ehub_sensors(slug, name, interval, config_id):
             f"{slug}_{EHUB}",
             f"{name} {EHUB_NAME}",
             interval,
+            precision_energy,
             config_id,
         ),
         ThreePhaseEnergyFerroampSensor(
@@ -847,6 +970,7 @@ def ehub_sensors(slug, name, interval, config_id):
             f"{slug}_{EHUB}",
             f"{name} {EHUB_NAME}",
             interval,
+            precision_energy,
             config_id,
         ),
         EnergyFerroampSensor(
@@ -856,6 +980,7 @@ def ehub_sensors(slug, name, interval, config_id):
             f"{slug}_{EHUB}",
             f"{name} {EHUB_NAME}",
             interval,
+            precision_energy,
             config_id,
         ),
         EnergyFerroampSensor(
@@ -865,6 +990,7 @@ def ehub_sensors(slug, name, interval, config_id):
             f"{slug}_{EHUB}",
             f"{name} {EHUB_NAME}",
             interval,
+            precision_energy,
             config_id,
         ),
         EnergyFerroampSensor(
@@ -874,6 +1000,7 @@ def ehub_sensors(slug, name, interval, config_id):
             f"{slug}_{EHUB}",
             f"{name} {EHUB_NAME}",
             interval,
+            precision_energy,
             config_id,
         ),
         IntValFerroampSensor(
@@ -901,6 +1028,7 @@ def ehub_sensors(slug, name, interval, config_id):
             f"{slug}_{EHUB}",
             f"{name} {EHUB_NAME}",
             interval,
+            precision_battery,
             config_id,
         ),
         BatteryFerroampSensor(
@@ -909,6 +1037,7 @@ def ehub_sensors(slug, name, interval, config_id):
             f"{slug}_{EHUB}",
             f"{name} {EHUB_NAME}",
             interval,
+            precision_battery,
             config_id,
         ),
         IntValFerroampSensor(
@@ -921,20 +1050,18 @@ def ehub_sensors(slug, name, interval, config_id):
             interval,
             config_id,
         ),
-        IntValFerroampSensor(
+        PowerFerroampSensor(
             f"{name} Solar Power",
             "ppv",
-            POWER_WATT,
             "mdi:solar-power",
             f"{slug}_{EHUB}",
             f"{name} {EHUB_NAME}",
             interval,
             config_id,
         ),
-        IntValFerroampSensor(
+        PowerFerroampSensor(
             f"{name} Battery Power",
             "pbat",
-            POWER_WATT,
             "mdi:battery",
             f"{slug}_{EHUB}",
             f"{name} {EHUB_NAME}",

--- a/custom_components/ferroamp/sensor.py
+++ b/custom_components/ferroamp/sensor.py
@@ -13,7 +13,6 @@ from homeassistant.const import (
     ENERGY_WATT_HOUR,
     FREQUENCY_HERTZ,
     PERCENTAGE,
-    POWER_KILO_WATT,
     POWER_WATT,
     TEMP_CELSIUS,
     VOLT
@@ -676,7 +675,7 @@ class CalculatedPowerFerroampSensor(FerroampSensor):
         super().__init__(
             name,
             voltage_key,
-            POWER_KILO_WATT,
+            POWER_WATT,
             icon,
             device_id,
             device_name,
@@ -702,7 +701,7 @@ class CalculatedPowerFerroampSensor(FerroampSensor):
                 temp_voltage += float(voltage["val"])
                 temp_current += float(current["val"])
 
-        self._state = int(round(temp_voltage / len(events) * temp_current / len(events) / 1000, 0))
+        self._state = int(round(temp_voltage / len(events) * temp_current / len(events), 0))
 
 
 class ThreePhaseFerroampSensor(FerroampSensor):

--- a/custom_components/ferroamp/strings.json
+++ b/custom_components/ferroamp/strings.json
@@ -21,9 +21,14 @@
     },
     "step": {
       "init": {
-        "title": "Update interval",
+        "title": "Ferroamp options",
         "data": {
-          "interval": "Update interval in seconds (defaults to 30 if left blank)"
+          "interval": "Update interval in seconds (defaults to 30 if left blank)",
+          "precision_battery": "Precision of battery sensors (number of decimals)",
+          "precision_current": "Precision of current sensors (number of decimals)",
+          "precision_energy": "Precision of energy sensors (number of decimals)",
+          "precision_temperature": "Precision of temperature sensors (number of decimals)",
+          "precision_voltage": "Precision of voltage sensors (number of decimals)"
         }
       }
     }

--- a/custom_components/ferroamp/translations/en.json
+++ b/custom_components/ferroamp/translations/en.json
@@ -21,9 +21,14 @@
     },
     "step": {
       "init": {
-        "title": "Update interval",
+        "title": "Ferroamp options",
         "data": {
-          "interval": "Update interval in seconds (defaults to 30 if left blank)"
+          "interval": "Update interval in seconds (defaults to 30 if left blank)",
+          "precision_battery": "Precision of battery sensors (number of decimals)",
+          "precision_current": "Precision of current sensors (number of decimals)",
+          "precision_energy": "Precision of energy sensors (number of decimals)",
+          "precision_temperature": "Precision of temperature sensors (number of decimals)",
+          "precision_voltage": "Precision of voltage sensors (number of decimals)"
         }
       }
     }

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2,7 +2,14 @@ from unittest import mock
 from homeassistant import data_entry_flow
 from custom_components.ferroamp import config_flow, CONF_NAME, CONF_PREFIX
 from pytest_homeassistant_custom_component.common import MockConfigEntry
-from custom_components.ferroamp.const import CONF_INTERVAL
+from custom_components.ferroamp.const import (
+    CONF_INTERVAL,
+    CONF_PRECISION_BATTERY,
+    CONF_PRECISION_CURRENT,
+    CONF_PRECISION_ENERGY,
+    CONF_PRECISION_TEMPERATURE,
+    CONF_PRECISION_VOLTAGE
+)
 
 
 async def test_flow_user_init(hass, mqtt_mock):
@@ -82,17 +89,32 @@ async def test_options_flow(hass, mqtt_mock):
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
-            CONF_INTERVAL: 20
+            CONF_INTERVAL: 20,
+            CONF_PRECISION_BATTERY: 1,
+            CONF_PRECISION_CURRENT: 2,
+            CONF_PRECISION_ENERGY: 3,
+            CONF_PRECISION_TEMPERATURE: 4,
+            CONF_PRECISION_VOLTAGE: 5
         }
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["data"] == {
-        CONF_INTERVAL: 20
+        CONF_INTERVAL: 20,
+        CONF_PRECISION_BATTERY: 1,
+        CONF_PRECISION_CURRENT: 2,
+        CONF_PRECISION_ENERGY: 3,
+        CONF_PRECISION_TEMPERATURE: 4,
+        CONF_PRECISION_VOLTAGE: 5
     }
     assert config_entry.data == {
         CONF_NAME: "Ferroamp",
         CONF_PREFIX: "extapi"
     }
     assert config_entry.options == {
-        CONF_INTERVAL: 20
+        CONF_INTERVAL: 20,
+        CONF_PRECISION_BATTERY: 1,
+        CONF_PRECISION_CURRENT: 2,
+        CONF_PRECISION_ENERGY: 3,
+        CONF_PRECISION_TEMPERATURE: 4,
+        CONF_PRECISION_VOLTAGE: 5
     }

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -7,8 +7,23 @@ from homeassistant.core import CoreState, State
 from homeassistant.helpers import entity_registry
 from pytest_homeassistant_custom_component.common import async_fire_mqtt_message, MockConfigEntry, mock_restore_cache
 
-from custom_components.ferroamp.const import DOMAIN, CONF_INTERVAL, DATA_DEVICES
-from custom_components.ferroamp.sensor import FerroampSensor
+from custom_components.ferroamp.const import (
+    DOMAIN,
+    CONF_INTERVAL,
+    CONF_PRECISION_BATTERY,
+    CONF_PRECISION_CURRENT,
+    CONF_PRECISION_ENERGY,
+    CONF_PRECISION_TEMPERATURE,
+    CONF_PRECISION_VOLTAGE,
+    DATA_DEVICES
+)
+from custom_components.ferroamp.sensor import (
+    FerroampSensor,
+    BatteryFerroampSensor,
+    EnergyFerroampSensor,
+    TemperatureFerroampSensor,
+    VoltageFerroampSensor
+)
 
 
 async def test_setting_ehub_sensor_values_via_mqtt_message(hass, mqtt_mock):
@@ -68,7 +83,7 @@ async def test_setting_ehub_sensor_values_via_mqtt_message(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("sensor.ferroamp_external_voltage")
-    assert state.state == "693"
+    assert state.state == "694"
     assert state.attributes == {
         'L1': 228.81,
         'L2': 233.81,
@@ -79,7 +94,7 @@ async def test_setting_ehub_sensor_values_via_mqtt_message(hass, mqtt_mock):
     }
 
     state = hass.states.get("sensor.ferroamp_inverter_rms_current")
-    assert state.state == "29"
+    assert state.state == "30"
     assert state.attributes == {
         'L1': 9.89,
         'L2': 9.85,
@@ -101,7 +116,7 @@ async def test_setting_ehub_sensor_values_via_mqtt_message(hass, mqtt_mock):
     }
 
     state = hass.states.get("sensor.ferroamp_grid_current")
-    assert state.state == "23"
+    assert state.state == "24"
     assert state.attributes == {
         'L1': 7.59,
         'L2': 8.9,
@@ -164,7 +179,7 @@ async def test_setting_ehub_sensor_values_via_mqtt_message(hass, mqtt_mock):
     }
 
     state = hass.states.get("sensor.ferroamp_grid_power_reactive")
-    assert state.state == "1544"
+    assert state.state == "1545"
     assert state.attributes == {
         'L1': 681.15,
         'L2': 327.35,
@@ -175,7 +190,7 @@ async def test_setting_ehub_sensor_values_via_mqtt_message(hass, mqtt_mock):
     }
 
     state = hass.states.get("sensor.ferroamp_inverter_power_active")
-    assert state.state == "-6722"
+    assert state.state == "-6723"
     assert state.attributes == {
         'L1': -2224.66,
         'L2': -2263.35,
@@ -208,7 +223,7 @@ async def test_setting_ehub_sensor_values_via_mqtt_message(hass, mqtt_mock):
     }
 
     state = hass.states.get("sensor.ferroamp_consumption_power_reactive")
-    assert state.state == "231"
+    assert state.state == "232"
     assert state.attributes == {
         'L1': 250.78,
         'L2': -110.77,
@@ -219,54 +234,54 @@ async def test_setting_ehub_sensor_values_via_mqtt_message(hass, mqtt_mock):
     }
 
     state = hass.states.get("sensor.ferroamp_external_energy_produced")
-    assert state.state == "660"
+    assert state.state == "662.4"
     assert state.attributes == {
-        'L1': 183.0,
-        'L2': 310.0,
-        'L3': 167.0,
+        'L1': 183.92,
+        'L2': 310.57,
+        'L3': 167.93,
         'friendly_name': 'Ferroamp External Energy Produced',
         'icon': 'mdi:power-plug',
         'unit_of_measurement': 'kWh'
     }
 
     state = hass.states.get("sensor.ferroamp_external_energy_consumed")
-    assert state.state == "6321"
+    assert state.state == "6322.6"
     assert state.attributes == {
-        'L1': 2021.0,
-        'L2': 1490.0,
-        'L3': 2810.0,
+        'L1': 2021.64,
+        'L2': 1490.26,
+        'L3': 2810.7,
         'friendly_name': 'Ferroamp External Energy Consumed',
         'icon': 'mdi:power-plug',
         'unit_of_measurement': 'kWh'
     }
 
     state = hass.states.get("sensor.ferroamp_inverter_energy_produced")
-    assert state.state == "2152"
+    assert state.state == "2152.5"
     assert state.attributes == {
-        'L1': 713.0,
-        'L2': 725.0,
-        'L3': 714.0,
+        'L1': 713.08,
+        'L2': 725.23,
+        'L3': 714.16,
         'friendly_name': 'Ferroamp Inverter Energy Produced',
         'icon': 'mdi:power-plug',
         'unit_of_measurement': 'kWh'
     }
 
     state = hass.states.get("sensor.ferroamp_inverter_energy_consumed")
-    assert state.state == "1211"
+    assert state.state == "1212.1"
     assert state.attributes == {
-        'L1': 399.0,
-        'L2': 409.0,
-        'L3': 403.0,
+        'L1': 399.01,
+        'L2': 409.75,
+        'L3': 403.32,
         'friendly_name': 'Ferroamp Inverter Energy Consumed',
         'icon': 'mdi:power-plug',
         'unit_of_measurement': 'kWh'
     }
 
     state = hass.states.get("sensor.ferroamp_load_energy_produced")
-    assert state.state == "5"
+    assert state.state == "5.0"
     assert state.attributes == {
         'L1': 0.0,
-        'L2': 5.0,
+        'L2': 5.01,
         'L3': 0.0,
         'friendly_name': 'Ferroamp Load Energy Produced',
         'icon': 'mdi:power-plug',
@@ -274,18 +289,18 @@ async def test_setting_ehub_sensor_values_via_mqtt_message(hass, mqtt_mock):
     }
 
     state = hass.states.get("sensor.ferroamp_load_energy_consumed")
-    assert state.state == "6739"
+    assert state.state == "6739.9"
     assert state.attributes == {
-        'L1': 2195.0,
-        'L2': 1530.0,
-        'L3': 3014.0,
+        'L1': 2195.03,
+        'L2': 1530.34,
+        'L3': 3014.51,
         'friendly_name': 'Ferroamp Load Energy Consumed',
         'icon': 'mdi:power-plug',
         'unit_of_measurement': 'kWh'
     }
 
     state = hass.states.get("sensor.ferroamp_total_solar_energy")
-    assert state.state == "1228"
+    assert state.state == "1228.4"
     assert state.attributes == {
         'friendly_name': 'Ferroamp Total Solar Energy',
         'icon': 'mdi:solar-power',
@@ -293,7 +308,7 @@ async def test_setting_ehub_sensor_values_via_mqtt_message(hass, mqtt_mock):
     }
 
     state = hass.states.get("sensor.ferroamp_battery_energy_produced")
-    assert state.state == "1366"
+    assert state.state == "1366.4"
     assert state.attributes == {
         'friendly_name': 'Ferroamp Battery Energy Produced',
         'icon': 'mdi:solar-power',
@@ -301,7 +316,7 @@ async def test_setting_ehub_sensor_values_via_mqtt_message(hass, mqtt_mock):
     }
 
     state = hass.states.get("sensor.ferroamp_battery_energy_consumed")
-    assert state.state == "1242"
+    assert state.state == "1242.4"
     assert state.attributes == {
         'friendly_name': 'Ferroamp Battery Energy Consumed',
         'icon': 'mdi:solar-power',
@@ -327,7 +342,7 @@ async def test_setting_ehub_sensor_values_via_mqtt_message(hass, mqtt_mock):
     }
 
     state = hass.states.get("sensor.ferroamp_system_state_of_charge")
-    assert state.state == "0"
+    assert state.state == "0.0"
     assert state.attributes == {
         'friendly_name': 'Ferroamp System State of Charge',
         'icon': 'mdi:battery-0',
@@ -335,7 +350,7 @@ async def test_setting_ehub_sensor_values_via_mqtt_message(hass, mqtt_mock):
     }
 
     state = hass.states.get("sensor.ferroamp_system_state_of_health")
-    assert state.state == "0"
+    assert state.state == "0.0"
     assert state.attributes == {
         'friendly_name': 'Ferroamp System State of Health',
         'icon': 'mdi:battery-0',
@@ -351,7 +366,7 @@ async def test_setting_ehub_sensor_values_via_mqtt_message(hass, mqtt_mock):
     }
 
     state = hass.states.get("sensor.ferroamp_solar_power")
-    assert state.state == "10107"
+    assert state.state == "10108"
     assert state.attributes == {
         'friendly_name': 'Ferroamp Solar Power',
         'icon': 'mdi:solar-power',
@@ -359,7 +374,7 @@ async def test_setting_ehub_sensor_values_via_mqtt_message(hass, mqtt_mock):
     }
 
     state = hass.states.get("sensor.ferroamp_battery_power")
-    assert state.state == "-3218"
+    assert state.state == "-3219"
     assert state.attributes == {
         'friendly_name': 'Ferroamp Battery Power',
         'icon': 'mdi:battery',
@@ -400,7 +415,7 @@ async def test_setting_esm_sensor_values_via_mqtt_message(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("sensor.ferroamp_esm_1_state_of_health")
-    assert state.state == "89"
+    assert state.state == "89.2"
     assert state.attributes == {
         'friendly_name': 'Ferroamp ESM 1 State of Health',
         'icon': 'mdi:battery-80',
@@ -408,7 +423,7 @@ async def test_setting_esm_sensor_values_via_mqtt_message(hass, mqtt_mock):
     }
 
     state = hass.states.get("sensor.ferroamp_esm_1_state_of_charge")
-    assert state.state == "45"
+    assert state.state == "45.5"
     assert state.attributes == {
         'friendly_name': 'Ferroamp ESM 1 State of Charge',
         'icon': 'mdi:battery-40',
@@ -449,7 +464,7 @@ async def test_battery_full(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("sensor.ferroamp_esm_1_state_of_charge")
-    assert state.state == "100"
+    assert state.state == "100.0"
     assert state.attributes == {
         'friendly_name': 'Ferroamp ESM 1 State of Charge',
         'icon': 'mdi:battery',
@@ -501,7 +516,7 @@ async def test_setting_eso_sensor_values_via_mqtt_message(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("sensor.ferroamp_eso_1_battery_voltage")
-    assert state.state == "622"
+    assert state.state == "623"
     assert state.attributes == {
         'friendly_name': 'Ferroamp ESO 1 Battery Voltage',
         'icon': 'mdi:battery',
@@ -509,7 +524,7 @@ async def test_setting_eso_sensor_values_via_mqtt_message(hass, mqtt_mock):
     }
 
     state = hass.states.get("sensor.ferroamp_eso_1_battery_current")
-    assert state.state == "1.57"
+    assert state.state == "2"
     assert state.attributes == {
         'friendly_name': 'Ferroamp ESO 1 Battery Current',
         'icon': 'mdi:battery',
@@ -517,7 +532,7 @@ async def test_setting_eso_sensor_values_via_mqtt_message(hass, mqtt_mock):
     }
 
     state = hass.states.get("sensor.ferroamp_eso_1_total_energy_produced")
-    assert state.state == "684"
+    assert state.state == "684.8"
     assert state.attributes == {
         'friendly_name': 'Ferroamp ESO 1 Total Energy Produced',
         'icon': 'mdi:battery',
@@ -525,7 +540,7 @@ async def test_setting_eso_sensor_values_via_mqtt_message(hass, mqtt_mock):
     }
 
     state = hass.states.get("sensor.ferroamp_eso_1_total_energy_consumed")
-    assert state.state == "614"
+    assert state.state == "614.9"
     assert state.attributes == {
         'friendly_name': 'Ferroamp ESO 1 Total Energy Consumed',
         'icon': 'mdi:battery',
@@ -533,7 +548,7 @@ async def test_setting_eso_sensor_values_via_mqtt_message(hass, mqtt_mock):
     }
 
     state = hass.states.get("sensor.ferroamp_eso_1_state_of_charge")
-    assert state.state == "48"
+    assert state.state == "48.1"
     assert state.attributes == {
         'friendly_name': 'Ferroamp ESO 1 State of Charge',
         'icon': 'mdi:battery-40',
@@ -557,7 +572,7 @@ async def test_setting_eso_sensor_values_via_mqtt_message(hass, mqtt_mock):
     }
 
     state = hass.states.get("sensor.ferroamp_eso_1_pcb_temperature")
-    assert state.state == "20.38"
+    assert state.state == "20"
     assert state.attributes == {
         'friendly_name': 'Ferroamp ESO 1 PCB Temperature',
         'icon': 'mdi:thermometer',
@@ -725,7 +740,7 @@ async def test_setting_sso_sensor_values_via_mqtt_message(hass, mqtt_mock):
     }
 
     state = hass.states.get("sensor.ferroamp_sso_1_pv_string_current")
-    assert state.state == "4.83"
+    assert state.state == "5"
     assert state.attributes == {
         'friendly_name': 'Ferroamp SSO 1 PV String Current',
         'icon': 'mdi:current-dc',
@@ -733,7 +748,7 @@ async def test_setting_sso_sensor_values_via_mqtt_message(hass, mqtt_mock):
     }
 
     state = hass.states.get("sensor.ferroamp_sso_1_pv_string_power")
-    assert state.state == "3.15"
+    assert state.state == "3"
     assert state.attributes == {
         'friendly_name': 'Ferroamp SSO 1 PV String Power',
         'icon': 'mdi:solar-power',
@@ -741,7 +756,7 @@ async def test_setting_sso_sensor_values_via_mqtt_message(hass, mqtt_mock):
     }
 
     state = hass.states.get("sensor.ferroamp_sso_1_total_energy")
-    assert state.state == "234"
+    assert state.state == "234.3"
     assert state.attributes == {
         'friendly_name': 'Ferroamp SSO 1 Total Energy',
         'icon': 'mdi:solar-power',
@@ -765,7 +780,7 @@ async def test_setting_sso_sensor_values_via_mqtt_message(hass, mqtt_mock):
     }
 
     state = hass.states.get("sensor.ferroamp_sso_1_pcb_temperature")
-    assert state.state == "6.48"
+    assert state.state == "6"
     assert state.attributes == {
         'friendly_name': 'Ferroamp SSO 1 PCB Temperature',
         'icon': 'mdi:thermometer',
@@ -804,7 +819,7 @@ async def test_restore_state(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("sensor.ferroamp_esm_1_state_of_charge")
-    assert state.state == "0"
+    assert state.state == "0.0"
     assert state.attributes == {
         'friendly_name': 'Ferroamp ESM 1 State of Charge',
         'icon': 'mdi:battery-0',
@@ -829,16 +844,23 @@ async def test_update_options(hass, mqtt_mock):
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    topic = "extapi/data/esm"
     msg = '{"id":{"val":"1"}}'
-    async_fire_mqtt_message(hass, topic, msg)
+    async_fire_mqtt_message(hass, "extapi/data/ehub", msg)
+    async_fire_mqtt_message(hass, "extapi/data/esm", msg)
+    async_fire_mqtt_message(hass, "extapi/data/eso", msg)
+    async_fire_mqtt_message(hass, "extapi/data/sso", msg)
     await hass.async_block_till_done()
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
     await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
-            CONF_INTERVAL: 20
+            CONF_INTERVAL: 20,
+            CONF_PRECISION_BATTERY: 1,
+            CONF_PRECISION_CURRENT: 2,
+            CONF_PRECISION_ENERGY: 0,
+            CONF_PRECISION_TEMPERATURE: 3,
+            CONF_PRECISION_VOLTAGE: 4,
         }
     )
     await hass.async_block_till_done()
@@ -847,8 +869,41 @@ async def test_update_options(hass, mqtt_mock):
     entity = er.async_get("sensor.ferroamp_esm_1_state_of_charge")
     assert entity is not None
     sensor = hass.data[DOMAIN][DATA_DEVICES][config_entry.unique_id]["ferroamp_esm_1"][entity.unique_id]
-    assert isinstance(sensor, FerroampSensor)
-    assert sensor.interval == 20
+    assert isinstance(sensor, BatteryFerroampSensor)
+    assert sensor._interval == 20
+    assert sensor._precision == 1
+
+    entity = er.async_get("sensor.ferroamp_total_solar_energy")
+    assert entity is not None
+    sensor = hass.data[DOMAIN][DATA_DEVICES][config_entry.unique_id]["ferroamp_ehub"][entity.unique_id]
+    assert isinstance(sensor, EnergyFerroampSensor)
+    assert sensor._interval == 20
+    assert sensor._precision == 0
+
+    entity = er.async_get("sensor.ferroamp_eso_1_pcb_temperature")
+    assert entity is not None
+    sensor = hass.data[DOMAIN][DATA_DEVICES][config_entry.unique_id]["ferroamp_eso_1"][entity.unique_id]
+    assert isinstance(sensor, TemperatureFerroampSensor)
+    assert sensor._interval == 20
+    assert sensor._precision == 3
+
+    entity = er.async_get("sensor.ferroamp_sso_1_pv_string_voltage")
+    assert entity is not None
+    sensor = hass.data[DOMAIN][DATA_DEVICES][config_entry.unique_id]["ferroamp_sso_1"][entity.unique_id]
+    assert isinstance(sensor, VoltageFerroampSensor)
+    assert sensor._interval == 20
+    assert sensor._precision == 4
+
+    async_fire_mqtt_message(hass, "extapi/data/ehub", msg)
+    async_fire_mqtt_message(hass, "extapi/data/esm", msg)
+    async_fire_mqtt_message(hass, "extapi/data/eso", msg)
+    async_fire_mqtt_message(hass, "extapi/data/sso", msg)
+    await hass.async_block_till_done()
+
+    entity = er.async_get("sensor.ferroamp_total_solar_energy")
+    assert entity is not None
+    sensor = hass.data[DOMAIN][DATA_DEVICES][config_entry.unique_id]["ferroamp_ehub"][entity.unique_id]
+    assert sensor.state == 0
 
 
 async def test_base_class_update_state_from_events():

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -531,6 +531,14 @@ async def test_setting_eso_sensor_values_via_mqtt_message(hass, mqtt_mock):
         'unit_of_measurement': 'A'
     }
 
+    state = hass.states.get("sensor.ferroamp_eso_1_battery_power")
+    assert state.state == "977"
+    assert state.attributes == {
+        'friendly_name': 'Ferroamp ESO 1 Battery Power',
+        'icon': 'mdi:battery',
+        'unit_of_measurement': 'W'
+    }
+
     state = hass.states.get("sensor.ferroamp_eso_1_total_energy_produced")
     assert state.state == "684.8"
     assert state.attributes == {
@@ -748,11 +756,11 @@ async def test_setting_sso_sensor_values_via_mqtt_message(hass, mqtt_mock):
     }
 
     state = hass.states.get("sensor.ferroamp_sso_1_pv_string_power")
-    assert state.state == "3"
+    assert state.state == "3151"
     assert state.attributes == {
         'friendly_name': 'Ferroamp SSO 1 PV String Power',
         'icon': 'mdi:solar-power',
-        'unit_of_measurement': 'kW'
+        'unit_of_measurement': 'W'
     }
 
     state = hass.states.get("sensor.ferroamp_sso_1_total_energy")


### PR DESCRIPTION
It's now possible to set the precision for battery, current, energy, power, temperature and voltage in the option flow.

Closes #16