### PR TITLE
feat: remove model-info from SSO-name

### DIFF
--- a/custom_components/ferroamp/sensor.py
+++ b/custom_components/ferroamp/sensor.py
@@ -3,6 +3,7 @@ import json
 import logging
 import uuid
 from datetime import datetime
+import re
 
 from homeassistant import config_entries, core
 from homeassistant.components import mqtt
@@ -48,6 +49,8 @@ CONTROL_RESULT_TOPIC = "control/result"
 
 EHUB = "ehub"
 EHUB_NAME = "EnergyHub"
+
+SSO_ID_REGEX = re.compile(r"^((PS\d+-[A-Z]\d+)-S)?(\d+)$")
 
 
 async def async_setup_entry(
@@ -136,6 +139,11 @@ async def async_setup_entry(
     def sso_event_received(msg):
         event = json.loads(msg.payload)
         sso_id = event["id"]["val"]
+        model = None
+        match = SSO_ID_REGEX.match(sso_id)
+        if match is not None:
+            sso_id = match.group(3)
+            model = match.group(2)
         device_id = f"{slug}_sso_{sso_id}"
         device_name = f"{name} SSO {sso_id}"
         store, new = get_store(device_id)
@@ -151,6 +159,7 @@ async def async_setup_entry(
                     interval,
                     precision_voltage,
                     config_id,
+                    model=model
                 ),
                 CurrentFerroampSensor(
                     f"{device_name} PV String Current",
@@ -160,7 +169,8 @@ async def async_setup_entry(
                     device_name,
                     interval,
                     precision_current,
-                    config_id
+                    config_id,
+                    model=model
                 ),
                 CalculatedPowerFerroampSensor(
                     f"{device_name} PV String Power",
@@ -171,6 +181,7 @@ async def async_setup_entry(
                     device_name,
                     interval,
                     config_id,
+                    model=model
                 ),
                 EnergyFerroampSensor(
                     f"{device_name} Total Energy",
@@ -181,6 +192,7 @@ async def async_setup_entry(
                     interval,
                     precision_energy,
                     config_id,
+                    model=model
                 ),
                 StringValFerroampSensor(
                     f"{device_name} Faultcode",
@@ -191,6 +203,7 @@ async def async_setup_entry(
                     device_name,
                     interval,
                     config_id,
+                    model=model
                 ),
                 RelayStatusFerroampSensor(
                     f"{device_name} Relay Status",
@@ -199,6 +212,7 @@ async def async_setup_entry(
                     device_name,
                     interval,
                     config_id,
+                    model=model
                 ),
                 TemperatureFerroampSensor(
                     f"{device_name} PCB Temperature",
@@ -207,7 +221,8 @@ async def async_setup_entry(
                     device_name,
                     interval,
                     precision_temperature,
-                    config_id
+                    config_id,
+                    model=model
                 ),
             ]
 
@@ -471,7 +486,7 @@ async def options_update_listener(hass, entry):
 class FerroampSensor(RestoreEntity):
     """Representation of a Ferroamp Sensor."""
 
-    def __init__(self, name, unit, icon, device_id, device_name, interval, config_id):
+    def __init__(self, name, unit, icon, device_id, device_name, interval, config_id, **kwargs):
         """Initialize the sensor."""
         self._state = None
         self._name = name
@@ -479,6 +494,7 @@ class FerroampSensor(RestoreEntity):
         self._icon = icon
         self._device_id = device_id
         self._device_name = device_name
+        self._device_model = kwargs.get("model")
         self._interval = interval
         self.config_id = config_id
         self.attrs = None
@@ -503,6 +519,7 @@ class FerroampSensor(RestoreEntity):
             "identifiers": {(DOMAIN, self._device_id)},
             "name": self._device_name,
             "manufacturer": MANUFACTURER,
+            "model": self._device_model
         }
         return device_info
 
@@ -540,9 +557,9 @@ class FerroampSensor(RestoreEntity):
 class KeyedFerroampSensor(FerroampSensor):
     """Representation of a Ferroamp Sensor using a single key to extract state from MQTT-messages."""
 
-    def __init__(self, name, key, unit, icon, device_id, device_name, interval, config_id):
+    def __init__(self, name, key, unit, icon, device_id, device_name, interval, config_id, **kwargs):
         """Initialize the sensor."""
-        super().__init__(name, unit, icon, device_id, device_name, interval, config_id)
+        super().__init__(name, unit, icon, device_id, device_name, interval, config_id, **kwargs)
         self._state_key = key
         self.updated = datetime.min
         self.event = {}
@@ -597,9 +614,9 @@ class IntValFerroampSensor(KeyedFerroampSensor):
 class StringValFerroampSensor(KeyedFerroampSensor):
     """Representation of a Ferroamp string value Sensor."""
 
-    def __init__(self, name, key, unit, icon, device_id, device_name, interval, config_id):
+    def __init__(self, name, key, unit, icon, device_id, device_name, interval, config_id, **kwargs):
         """Initialize the sensor."""
-        super().__init__(name, key, unit, icon, device_id, device_name, interval, config_id)
+        super().__init__(name, key, unit, icon, device_id, device_name, interval, config_id, **kwargs)
 
     def update_state_from_events(self, events):
         temp = None
@@ -616,9 +633,9 @@ class StringValFerroampSensor(KeyedFerroampSensor):
 class FloatValFerroampSensor(KeyedFerroampSensor):
     """Representation of a Ferroamp float value Sensor."""
 
-    def __init__(self, name, key, unit, icon, device_id, device_name, interval, precision, config_id):
+    def __init__(self, name, key, unit, icon, device_id, device_name, interval, precision, config_id, **kwargs):
         """Initialize the sensor."""
-        super().__init__(name, key, unit, icon, device_id, device_name, interval, config_id)
+        super().__init__(name, key, unit, icon, device_id, device_name, interval, config_id, **kwargs)
         self._precision = precision
 
     def update_state_from_events(self, events):
@@ -684,9 +701,9 @@ class BatteryFerroampSensor(FloatValFerroampSensor):
 
 
 class TemperatureFerroampSensor(FloatValFerroampSensor):
-    def __init__(self, name, key, device_id, device_name, interval, precision, config_id):
+    def __init__(self, name, key, device_id, device_name, interval, precision, config_id, **kwargs):
         super().__init__(
-            name, key, TEMP_CELSIUS, "mdi:thermometer", device_id, device_name, interval, precision, config_id
+            name, key, TEMP_CELSIUS, "mdi:thermometer", device_id, device_name, interval, precision, config_id, **kwargs
         )
 
     def handle_options_update(self, options):
@@ -695,7 +712,7 @@ class TemperatureFerroampSensor(FloatValFerroampSensor):
 
 
 class CurrentFerroampSensor(FloatValFerroampSensor):
-    def __init__(self, name, key, icon, device_id, device_name, interval, precision, config_id):
+    def __init__(self, name, key, icon, device_id, device_name, interval, precision, config_id, **kwargs):
         super().__init__(
             name,
             key,
@@ -705,7 +722,8 @@ class CurrentFerroampSensor(FloatValFerroampSensor):
             device_name,
             interval,
             precision,
-            config_id
+            config_id,
+            **kwargs
         )
 
     def handle_options_update(self, options):
@@ -714,9 +732,9 @@ class CurrentFerroampSensor(FloatValFerroampSensor):
 
 
 class VoltageFerroampSensor(FloatValFerroampSensor):
-    def __init__(self, name, key, icon, device_id, device_name, interval, precision, config_id):
+    def __init__(self, name, key, icon, device_id, device_name, interval, precision, config_id, **kwargs):
         super().__init__(
-            name, key, VOLT, icon, device_id, device_name, interval, precision, config_id
+            name, key, VOLT, icon, device_id, device_name, interval, precision, config_id, **kwargs
         )
 
     def handle_options_update(self, options):
@@ -727,9 +745,20 @@ class VoltageFerroampSensor(FloatValFerroampSensor):
 class EnergyFerroampSensor(FloatValFerroampSensor):
     """Representation of a Ferroamp energy in kWh value Sensor."""
 
-    def __init__(self, name, key, icon, device_id, device_name, interval, precision, config_id):
+    def __init__(self, name, key, icon, device_id, device_name, interval, precision, config_id, **kwargs):
         """Initialize the sensor"""
-        super().__init__(name, key, ENERGY_KILO_WATT_HOUR, icon, device_id, device_name, interval, precision, config_id)
+        super().__init__(
+            name,
+            key,
+            ENERGY_KILO_WATT_HOUR,
+            icon,
+            device_id,
+            device_name,
+            interval,
+            precision,
+            config_id,
+            **kwargs
+        )
 
     def update_state_from_events(self, events):
         temp = 0
@@ -749,9 +778,9 @@ class EnergyFerroampSensor(FloatValFerroampSensor):
 
 
 class RelayStatusFerroampSensor(KeyedFerroampSensor):
-    def __init__(self, name, key, device_id, device_name, interval, config_id):
+    def __init__(self, name, key, device_id, device_name, interval, config_id, **kwargs):
         """Initialize the sensor"""
-        super().__init__(name, key, "", "", device_id, device_name, interval, config_id)
+        super().__init__(name, key, "", "", device_id, device_name, interval, config_id, **kwargs)
 
     def update_state_from_events(self, events):
         temp = None
@@ -781,7 +810,7 @@ class PowerFerroampSensor(FloatValFerroampSensor):
 class CalculatedPowerFerroampSensor(KeyedFerroampSensor):
     """Representation of a Ferroamp Power Sensor based on V and A."""
 
-    def __init__(self, name, voltage_key, current_key, icon, device_id, device_name, interval, config_id):
+    def __init__(self, name, voltage_key, current_key, icon, device_id, device_name, interval, config_id, **kwargs):
         """Initialize the sensor."""
         super().__init__(
             name,
@@ -791,7 +820,8 @@ class CalculatedPowerFerroampSensor(KeyedFerroampSensor):
             device_id,
             device_name,
             interval,
-            config_id
+            config_id,
+            **kwargs
         )
         self._voltage_key = voltage_key
         self._current_key = current_key

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -788,68 +788,167 @@ async def test_setting_sso_sensor_values_via_mqtt_message(hass, mqtt_mock):
                 "faultcode": {"val": "0"},
                 "ipv": {"val": "4.826"},
                 "upv": {"val": "653.012"},
-                "id": {"val": "1"}
+                "id": {"val": "12345678"}
             }"""
     async_fire_mqtt_message(hass, topic, msg)
     await hass.async_block_till_done()
     async_fire_mqtt_message(hass, topic, msg)
     await hass.async_block_till_done()
 
-    state = hass.states.get("sensor.ferroamp_sso_1_pv_string_voltage")
+    state = hass.states.get("sensor.ferroamp_sso_12345678_pv_string_voltage")
     assert state.state == "653"
     assert state.attributes == {
-        'friendly_name': 'Ferroamp SSO 1 PV String Voltage',
+        'friendly_name': 'Ferroamp SSO 12345678 PV String Voltage',
         'icon': 'mdi:current-dc',
         'unit_of_measurement': 'V'
     }
 
-    state = hass.states.get("sensor.ferroamp_sso_1_pv_string_current")
+    state = hass.states.get("sensor.ferroamp_sso_12345678_pv_string_current")
     assert state.state == "5"
     assert state.attributes == {
-        'friendly_name': 'Ferroamp SSO 1 PV String Current',
+        'friendly_name': 'Ferroamp SSO 12345678 PV String Current',
         'icon': 'mdi:current-dc',
         'unit_of_measurement': 'A'
     }
 
-    state = hass.states.get("sensor.ferroamp_sso_1_pv_string_power")
+    state = hass.states.get("sensor.ferroamp_sso_12345678_pv_string_power")
     assert state.state == "3151"
     assert state.attributes == {
-        'friendly_name': 'Ferroamp SSO 1 PV String Power',
+        'friendly_name': 'Ferroamp SSO 12345678 PV String Power',
         'icon': 'mdi:solar-power',
         'unit_of_measurement': 'W'
     }
 
-    state = hass.states.get("sensor.ferroamp_sso_1_total_energy")
+    state = hass.states.get("sensor.ferroamp_sso_12345678_total_energy")
     assert state.state == "234.3"
     assert state.attributes == {
-        'friendly_name': 'Ferroamp SSO 1 Total Energy',
+        'friendly_name': 'Ferroamp SSO 12345678 Total Energy',
         'icon': 'mdi:solar-power',
         'unit_of_measurement': 'kWh'
     }
 
-    state = hass.states.get("sensor.ferroamp_sso_1_faultcode")
+    state = hass.states.get("sensor.ferroamp_sso_12345678_faultcode")
     assert state.state == "0"
     assert state.attributes == {
-        'friendly_name': 'Ferroamp SSO 1 Faultcode',
+        'friendly_name': 'Ferroamp SSO 12345678 Faultcode',
         'icon': 'mdi:traffic-light',
         'unit_of_measurement': ''
     }
 
-    state = hass.states.get("sensor.ferroamp_sso_1_relay_status")
+    state = hass.states.get("sensor.ferroamp_sso_12345678_relay_status")
     assert state.state == "closed"
     assert state.attributes == {
-        'friendly_name': 'Ferroamp SSO 1 Relay Status',
+        'friendly_name': 'Ferroamp SSO 12345678 Relay Status',
         'icon': '',
         'unit_of_measurement': ''
     }
 
-    state = hass.states.get("sensor.ferroamp_sso_1_pcb_temperature")
+    state = hass.states.get("sensor.ferroamp_sso_12345678_pcb_temperature")
     assert state.state == "6"
     assert state.attributes == {
-        'friendly_name': 'Ferroamp SSO 1 PCB Temperature',
+        'friendly_name': 'Ferroamp SSO 12345678 PCB Temperature',
         'icon': 'mdi:thermometer',
         'unit_of_measurement': '°C'
     }
+
+
+async def test_trim_part_no_from_sso_id(hass, mqtt_mock):
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_NAME: "Ferroamp",
+            CONF_PREFIX: "extapi"
+        },
+        options={
+            CONF_INTERVAL: 0
+        },
+        version=1,
+        unique_id="ferroamp",
+    )
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    topic = "extapi/data/sso"
+    msg = """{
+                "relaystatus": {"val": "0"},
+                "temp": {"val": "6.482"},
+                "wpv": {"val": "843516404273"},
+                "ts": {"val": "2021-03-08T08:22:42UTC"},
+                "udc": {"val": "769.872"},
+                "faultcode": {"val": "0"},
+                "ipv": {"val": "4.826"},
+                "upv": {"val": "653.012"},
+                "id": {"val": "PS00990-A02-S12345678"}
+            }"""
+
+    async_fire_mqtt_message(hass, topic, msg)
+    await hass.async_block_till_done()
+    async_fire_mqtt_message(hass, topic, msg)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.ferroamp_sso_12345678_pv_string_voltage")
+    assert state.state == "653"
+    assert state.attributes == {
+        'friendly_name': 'Ferroamp SSO 12345678 PV String Voltage',
+        'icon': 'mdi:current-dc',
+        'unit_of_measurement': 'V'
+    }
+
+    state = hass.states.get("sensor.ferroamp_sso_12345678_pv_string_current")
+    assert state.state == "5"
+    assert state.attributes == {
+        'friendly_name': 'Ferroamp SSO 12345678 PV String Current',
+        'icon': 'mdi:current-dc',
+        'unit_of_measurement': 'A'
+    }
+
+    state = hass.states.get("sensor.ferroamp_sso_12345678_pv_string_power")
+    assert state.state == "3151"
+    assert state.attributes == {
+        'friendly_name': 'Ferroamp SSO 12345678 PV String Power',
+        'icon': 'mdi:solar-power',
+        'unit_of_measurement': 'W'
+    }
+
+    state = hass.states.get("sensor.ferroamp_sso_12345678_total_energy")
+    assert state.state == "234.3"
+    assert state.attributes == {
+        'friendly_name': 'Ferroamp SSO 12345678 Total Energy',
+        'icon': 'mdi:solar-power',
+        'unit_of_measurement': 'kWh'
+    }
+
+    state = hass.states.get("sensor.ferroamp_sso_12345678_faultcode")
+    assert state.state == "0"
+    assert state.attributes == {
+        'friendly_name': 'Ferroamp SSO 12345678 Faultcode',
+        'icon': 'mdi:traffic-light',
+        'unit_of_measurement': ''
+    }
+
+    state = hass.states.get("sensor.ferroamp_sso_12345678_relay_status")
+    assert state.state == "closed"
+    assert state.attributes == {
+        'friendly_name': 'Ferroamp SSO 12345678 Relay Status',
+        'icon': '',
+        'unit_of_measurement': ''
+    }
+
+    state = hass.states.get("sensor.ferroamp_sso_12345678_pcb_temperature")
+    assert state.state == "6"
+    assert state.attributes == {
+        'friendly_name': 'Ferroamp SSO 12345678 PCB Temperature',
+        'icon': 'mdi:thermometer',
+        'unit_of_measurement': '°C'
+    }
+
+    er = await entity_registry.async_get_registry(hass)
+    entity = er.async_get("sensor.ferroamp_sso_12345678_pv_string_voltage")
+    assert entity is not None
+    sensor = hass.data[DOMAIN][DATA_DEVICES][config_entry.unique_id]["ferroamp_sso_12345678"][entity.unique_id]
+    assert isinstance(sensor, VoltageFerroampSensor)
+    assert sensor._device_model == "PS00990-A02"
 
 
 async def test_restore_state(hass, mqtt_mock):


### PR DESCRIPTION
Closes #26

@danielolsson100 I have removed the model from the name (this is then a breaking change for anyone with Gen2 SSO's since the entity id's will be different) and added it as model to the device instead.