### PR TITLE
feat: add textual representation of ESO faultcodes as attributes

### DIFF
--- a/custom_components/ferroamp/const.py
+++ b/custom_components/ferroamp/const.py
@@ -12,3 +12,19 @@ DATA_LISTENERS = "listeners"
 DATA_PREFIXES = "prefixes"
 DOMAIN = "ferroamp"
 MANUFACTURER = "Ferroamp"
+
+ESO_FAULT_CODES = [
+    "The pre-charge from battery to ESO is not reaching the voltage goal prohibiting the closing of the relays.",
+    "CAN communication issues between ESO and battery.",
+    """This indicates that the SoC limits for the batteries are not configured correctly,
+please contact Ferroamp Support for help.""",
+    """This indicates that the power limits for the batteries are incorrect or non-optimal.
+When controlling batteries via extapi and the system is set in either peak-shaving or
+self-consumption modes this flag may be set but it will not affect control.
+When not controlling batteries via extapi this indicates that the settings made in EMS Configuration is invalid.""",
+    "On-site emergency stop has been triggered.",
+    "The DC-link voltage in ESO is so high that it prevents operation.",
+    """Indicates that the battery has an alarm or an error flag raised. Please check Battery manufacturer’s manual
+for trouble shooting the battery, or call Ferroamp Support.""",
+    "Not a fault, just an indication that Battery Manufacturer is not Ferroamp",
+]

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -793,7 +793,8 @@ async def test_setting_eso_sensor_values_via_mqtt_message(hass, mqtt_mock):
     assert state.attributes == {
         'friendly_name': 'Ferroamp ESO 1 Faultcode',
         'icon': 'mdi:traffic-light',
-        'unit_of_measurement': ''
+        'unit_of_measurement': '',
+        7: 'Not a fault, just an indication that Battery Manufacturer is not Ferroamp'
     }
 
     state = hass.states.get("sensor.ferroamp_eso_1_relay_status")


### PR DESCRIPTION
@danielolsson100 Something like this? Would be nice to get the same for SSO from Ferroamp as well 😉 