### PR TITLE
build: remove direct dependency on voluptous

### DIFF
--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -4,4 +4,3 @@ pytest-homeassistant-custom-component==0.4.4
 # From our manifest.json for our custom component
 aiohttp_cors==0.7.0
 paho-mqtt==1.5.1
-voluptuous==0.12.1


### PR DESCRIPTION
We get this dependency from pytest-homeassistant-custom-component anyway