### PR TITLE
fix: make relay status history available

### DIFF
--- a/custom_components/ferroamp/sensor.py
+++ b/custom_components/ferroamp/sensor.py
@@ -1,4 +1,6 @@
 """Platform for Ferroamp sensors integration."""
+from __future__ import annotations
+
 import json
 import logging
 import uuid
@@ -564,7 +566,7 @@ async def options_update_listener(hass, entry):
 class FerroampSensor(SensorEntity, RestoreEntity):
     """Representation of a Ferroamp Sensor."""
 
-    def __init__(self, name, entity_prefix, unit, icon, device_id, device_name, interval, config_id, **kwargs):
+    def __init__(self, name, entity_prefix, unit: str | None, icon, device_id, device_name, interval, config_id, **kwargs):
         """Initialize the sensor."""
         self._attr_name = name
         self._attr_unit_of_measurement = unit
@@ -611,7 +613,7 @@ class FerroampSensor(SensorEntity, RestoreEntity):
 class KeyedFerroampSensor(FerroampSensor):
     """Representation of a Ferroamp Sensor using a single key to extract state from MQTT-messages."""
 
-    def __init__(self, name, entity_prefix, key, unit, icon, device_id, device_name, interval, config_id, **kwargs):
+    def __init__(self, name, entity_prefix, key, unit: str | None, icon, device_id, device_name, interval, config_id, **kwargs):
         """Initialize the sensor."""
         super().__init__(name, entity_prefix, unit, icon, device_id, device_name, interval, config_id, **kwargs)
         self._state_key = key
@@ -646,7 +648,7 @@ class KeyedFerroampSensor(FerroampSensor):
 class IntValFerroampSensor(KeyedFerroampSensor):
     """Representation of a Ferroamp integer value Sensor."""
 
-    def __init__(self, name, entity_prefix, key, unit, icon, device_id, device_name, interval, config_id, **kwargs):
+    def __init__(self, name, entity_prefix, key, unit: str | None, icon, device_id, device_name, interval, config_id, **kwargs):
         """Initialize the sensor."""
         super().__init__(name, entity_prefix, key, unit, icon, device_id, device_name, interval, config_id, **kwargs)
 
@@ -668,7 +670,7 @@ class IntValFerroampSensor(KeyedFerroampSensor):
 class StringValFerroampSensor(KeyedFerroampSensor):
     """Representation of a Ferroamp string value Sensor."""
 
-    def __init__(self, name, entity_prefix, key, unit, icon, device_id, device_name, interval, config_id, **kwargs):
+    def __init__(self, name, entity_prefix, key, unit: str | None, icon, device_id, device_name, interval, config_id, **kwargs):
         """Initialize the sensor."""
         super().__init__(name, entity_prefix, key, unit, icon, device_id, device_name, interval, config_id, **kwargs)
 
@@ -688,7 +690,7 @@ class StringValFerroampSensor(KeyedFerroampSensor):
 class FloatValFerroampSensor(KeyedFerroampSensor):
     """Representation of a Ferroamp float value Sensor."""
 
-    def __init__(self, name, entity_prefix, key, unit, icon, device_id, device_name, interval, precision, config_id, **kwargs):
+    def __init__(self, name, entity_prefix, key, unit: str | None, icon, device_id, device_name, interval, precision, config_id, **kwargs):
         """Initialize the sensor."""
         super().__init__(name, entity_prefix, key, unit, icon, device_id, device_name, interval, config_id, **kwargs)
         self._precision = precision
@@ -878,7 +880,7 @@ class EnergyFerroampSensor(FloatValFerroampSensor):
 class RelayStatusFerroampSensor(KeyedFerroampSensor):
     def __init__(self, name, entity_prefix, key, device_id, device_name, interval, config_id, **kwargs):
         """Initialize the sensor"""
-        super().__init__(name, entity_prefix, key, "", "", device_id, device_name, interval, config_id, **kwargs)
+        super().__init__(name, entity_prefix, key, None, "", device_id, device_name, interval, config_id, **kwargs)
 
     def update_state_from_events(self, events):
         temp = None
@@ -950,7 +952,7 @@ class CalculatedPowerFerroampSensor(KeyedFerroampSensor):
 class ThreePhaseFerroampSensor(KeyedFerroampSensor):
     """Representation of a Ferroamp ThreePhase Sensor."""
 
-    def __init__(self, name, entity_prefix, key, unit, icon, device_id, device_name, interval, precision, config_id, **kwargs):
+    def __init__(self, name, entity_prefix, key, unit: str | None, icon, device_id, device_name, interval, precision, config_id, **kwargs):
         """Initialize the sensor."""
         super().__init__(name, entity_prefix, key, unit, icon, device_id, device_name, interval, config_id, **kwargs)
         if self._attr_state_class is None:
@@ -1086,7 +1088,7 @@ class FaultcodeFerroampSensor(KeyedFerroampSensor):
 
     def __init__(self, name, entity_prefix, key, device_id, device_name, interval, fault_codes, config_id, **kwargs):
         """Initialize the sensor."""
-        super().__init__(name, entity_prefix, key, "", "mdi:traffic-light", device_id, device_name, interval, config_id,
+        super().__init__(name, entity_prefix, key, None, "mdi:traffic-light", device_id, device_name, interval, config_id,
                          **kwargs)
         self._fault_codes = fault_codes
         self._attr_extra_state_attributes = {}

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -865,7 +865,6 @@ async def test_setting_eso_sensor_values_via_mqtt_message(hass, mqtt_mock):
     assert state.attributes == {
         'friendly_name': 'ESO 1 Faultcode',
         'icon': 'mdi:traffic-light',
-        'unit_of_measurement': '',
         8: 'Not a fault, just an indication that Battery Manufacturer is not Ferroamp'
     }
 
@@ -874,7 +873,6 @@ async def test_setting_eso_sensor_values_via_mqtt_message(hass, mqtt_mock):
     assert state.attributes == {
         'friendly_name': 'ESO 1 Relay Status',
         'icon': '',
-        'unit_of_measurement': ''
     }
 
     state = hass.states.get("sensor.ferroamp_eso_1_pcb_temperature")
@@ -1032,7 +1030,6 @@ async def test_setting_sso_sensor_values_via_mqtt_message(hass, mqtt_mock):
     assert state.attributes == {
         'friendly_name': 'SSO 12345678 Faultcode',
         'icon': 'mdi:traffic-light',
-        'unit_of_measurement': '',
         0: 'No errors'
     }
 
@@ -1041,7 +1038,6 @@ async def test_setting_sso_sensor_values_via_mqtt_message(hass, mqtt_mock):
     assert state.attributes == {
         'friendly_name': 'SSO 12345678 Relay Status',
         'icon': '',
-        'unit_of_measurement': ''
     }
 
     state = hass.states.get("sensor.ferroamp_sso_12345678_pcb_temperature")
@@ -1122,7 +1118,6 @@ async def test_trim_part_no_from_sso_id(hass, mqtt_mock):
     assert state.attributes == {
         'friendly_name': 'SSO 12345678 Faultcode',
         'icon': 'mdi:traffic-light',
-        'unit_of_measurement': '',
         0: 'No errors'
     }
 
@@ -1131,7 +1126,6 @@ async def test_trim_part_no_from_sso_id(hass, mqtt_mock):
     assert state.attributes == {
         'friendly_name': 'SSO 12345678 Relay Status',
         'icon': '',
-        'unit_of_measurement': ''
     }
 
     state = hass.states.get("sensor.ferroamp_sso_12345678_pcb_temperature")
@@ -1214,7 +1208,6 @@ async def test_sso_fault_codes(hass, mqtt_mock):
     assert state.attributes == {
         'friendly_name': 'SSO 12345678 Faultcode',
         'icon': 'mdi:traffic-light',
-        'unit_of_measurement': '',
         0: 'No errors'
     }
 
@@ -1237,7 +1230,6 @@ async def test_sso_fault_codes(hass, mqtt_mock):
     assert state.attributes == {
         'friendly_name': 'SSO 12345678 Faultcode',
         'icon': 'mdi:traffic-light',
-        'unit_of_measurement': '',
         5: 'UNDERVOLTAGE'
     }
 
@@ -1260,7 +1252,6 @@ async def test_sso_fault_codes(hass, mqtt_mock):
     assert state.attributes == {
         'friendly_name': 'SSO 12345678 Faultcode',
         'icon': 'mdi:traffic-light',
-        'unit_of_measurement': '',
         6: 'OVERVOLTAGE'
     }
 
@@ -1283,7 +1274,6 @@ async def test_sso_fault_codes(hass, mqtt_mock):
     assert state.attributes == {
         'friendly_name': 'SSO 12345678 Faultcode',
         'icon': 'mdi:traffic-light',
-        'unit_of_measurement': '',
         7: 'OVERHEAT'
     }
 
@@ -1306,7 +1296,6 @@ async def test_sso_fault_codes(hass, mqtt_mock):
     assert state.attributes == {
         'friendly_name': 'SSO 12345678 Faultcode',
         'icon': 'mdi:traffic-light',
-        'unit_of_measurement': '',
         11: 'POWERLIMITING'
     }
 


### PR DESCRIPTION
The problem was that unit of measurement was set to empty string instead of None.
Started to introduce strict typing to allow it to be either a string or
None.

Closes #92