### PR TITLE
fix: battery icon when below 10 percent is not valid

### DIFF
--- a/custom_components/ferroamp/sensor.py
+++ b/custom_components/ferroamp/sensor.py
@@ -28,6 +28,7 @@ from homeassistant.const import (
 from homeassistant.core import callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_registry import async_get as async_get_entity_reg
+from homeassistant.helpers.icon import icon_for_battery_level
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.util import slugify
 
@@ -751,7 +752,7 @@ class PercentageFerroampSensor(FloatValFerroampSensor):
         if self.state is not None and self.state != "unknown":
             pct = int(float(self.state) / 10) * 10
             if pct <= 90:
-                self._attr_icon = f"mdi:battery-{pct}"
+                self._attr_icon = icon_for_battery_level(battery_level=pct)
             else:
                 self._attr_icon = "mdi:battery"
         return res


### PR DESCRIPTION
when battery level is below 10 today it selects mdi:battery-level-9 for example and this is not a valid icon so i have changed to utilize the built in icon helper for battery from home assistant.