### PR TITLE
fix: ignore zero values for total-increasing energy sensors

### DIFF
--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,5 +1,6 @@
 import uuid
 from unittest.mock import patch
+import unittest
 
 import pytest
 from homeassistant.const import (
@@ -1692,6 +1693,47 @@ async def test_always_increasing(hass, mqtt_mock):
     sensor = hass.data[DOMAIN][DATA_DEVICES][config_entry.unique_id]["ferroamp_ehub"][entity.unique_id]
     assert sensor.state == "1348.5"
 
+async def test_always_increasing_zerovalues(hass, mqtt_mock):
+    mock_restore_cache(
+        hass,
+        [
+            State("sensor.ferroamp_total_solar_energy", "1348.5")
+        ],
+    )
+
+    hass.state = CoreState.starting
+
+    config_entry = create_config()
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    topic = "extapi/data/ehub"
+    async_fire_mqtt_message(hass, topic, '{"id":{"val":"1"},"wpv":{"val": "4422089590383"}}')
+    async_fire_mqtt_message(hass, topic, '{"id":{"val":"1"},"wpv":{"val": "0"}}')
+    await hass.async_block_till_done()
+
+    er = entity_registry.async_get(hass)
+    entity = er.async_get("sensor.ferroamp_total_solar_energy")
+    assert entity is not None
+    sensor = hass.data[DOMAIN][DATA_DEVICES][config_entry.unique_id]["ferroamp_ehub"][entity.unique_id]
+    assert float(sensor.state) == pytest.approx(1348.5)
+
+    async_fire_mqtt_message(hass, topic, '{"id":{"val":"1"},"wpv":{"val": "4856400000000"}}')
+    async_fire_mqtt_message(hass, topic, '{"id":{"val":"1"},"wpv":{"val": "0"}}')
+    async_fire_mqtt_message(hass, topic, '{"id":{"val":"1"},"wpv":{"val": "0"}}')
+    async_fire_mqtt_message(hass, topic, '{"id":{"val":"1"},"wpv":{"val": "0"}}')
+    async_fire_mqtt_message(hass, topic, '{"id":{"val":"1"},"wpv":{"val": "0"}}')
+    async_fire_mqtt_message(hass, topic, '{"id":{"val":"1"},"wpv":{"val": "0"}}')
+    async_fire_mqtt_message(hass, topic, '{"id":{"val":"1"},"wpv":{"val": "0"}}')
+    async_fire_mqtt_message(hass, topic, '{"id":{"val":"1"},"wpv":{"val": "4856400000000"}}')
+    await hass.async_block_till_done()
+
+    er = entity_registry.async_get(hass)
+    entity = er.async_get("sensor.ferroamp_total_solar_energy")
+    assert entity is not None
+    sensor = hass.data[DOMAIN][DATA_DEVICES][config_entry.unique_id]["ferroamp_ehub"][entity.unique_id]
+    assert float(sensor.state) == pytest.approx(1349.0)
+
 
 async def test_always_increasing_unknown_value(hass, mqtt_mock):
     mock_restore_cache(
@@ -1771,6 +1813,52 @@ async def test_3phase_always_increasing(hass, mqtt_mock):
     sensor = hass.data[DOMAIN][DATA_DEVICES][config_entry.unique_id]["ferroamp_ehub"][entity.unique_id]
     assert sensor.state == "662.5"
 
+async def test_3phase_always_increasing_zero_values(hass, mqtt_mock):
+    mock_restore_cache(
+        hass,
+        [
+            State("sensor.ferroamp_external_energy_produced", "662.5")
+        ],
+    )
+
+    hass.state = CoreState.starting
+
+    config_entry = create_config()
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    topic = "extapi/data/ehub"
+    msg = '{"id":{"val":"1"},"wextprodq": {"L2": "1118056851556", "L3": "604554554552", "L1": "662115344893"}}'
+    async_fire_mqtt_message(hass, topic, msg)
+    msg = '{"id":{"val":"1"},"wextprodq": {"L2": "0", "L3": "0", "L1": "0"}}'
+    async_fire_mqtt_message(hass, topic, msg)
+    async_fire_mqtt_message(hass, topic, msg)
+    async_fire_mqtt_message(hass, topic, msg)
+    await hass.async_block_till_done()
+
+    er = entity_registry.async_get(hass)
+    entity = er.async_get("sensor.ferroamp_external_energy_produced")
+    assert entity is not None
+    sensor = hass.data[DOMAIN][DATA_DEVICES][config_entry.unique_id]["ferroamp_ehub"][entity.unique_id]
+    assert float(sensor.state) == pytest.approx(662.5)
+
+    msg = '{"id":{"val":"1"},"wextprodq": {"L2": "1118056851556", "L3": "604554554552", "L1": "662115344893"}}'
+    async_fire_mqtt_message(hass, topic, msg)
+    msg = '{"id":{"val":"1"},"wextprodq": {"L2": "0", "L3": "0", "L1": "0"}}'
+    async_fire_mqtt_message(hass, topic, msg)
+    async_fire_mqtt_message(hass, topic, msg)
+    async_fire_mqtt_message(hass, topic, msg)
+    msg = '{"id":{"val":"1"},"wextprodq": {"L2": "1119056851556", "L3": "604564554552", "L1": "662116344893"}}'
+    async_fire_mqtt_message(hass, topic, msg)
+    msg = '{"id":{"val":"1"},"wextprodq": {"L2": "0", "L3": "0", "L1": "0"}}'
+    async_fire_mqtt_message(hass, topic, msg)
+    await hass.async_block_till_done()
+
+    er = entity_registry.async_get(hass)
+    entity = er.async_get("sensor.ferroamp_external_energy_produced")
+    assert entity is not None
+    sensor = hass.data[DOMAIN][DATA_DEVICES][config_entry.unique_id]["ferroamp_ehub"][entity.unique_id]
+    assert float(sensor.state) == pytest.approx(662.7)
 
 async def test_3phase_always_increasing_unknown_value(hass, mqtt_mock):
     mock_restore_cache(


### PR DESCRIPTION
Energy sensors seems to be 0 every now and then for some users.
This commit ignores such values before they reach the average
calculation.

This commit also moves the assignment of `SensorStateClass.TOTAL_INCREASING`
into energy sensor classes since they always are total increasing.
This way we can assume objects of this class are always total
increasing.

Refs #318