### PR TITLE
fix: correct calculation dc link voltage sensor state

### DIFF
--- a/custom_components/ferroamp/sensor.py
+++ b/custom_components/ferroamp/sensor.py
@@ -756,7 +756,7 @@ class DcLinkFerroampSensor(KeyedFerroampSensor):
         if neg is None and pos is None:
             return False
         else:
-            self._attr_native_value = int(neg / count + pos / count)
+            self._attr_native_value = round(float(pos / count - neg / count), 2)
             self._attr_extra_state_attributes = dict(neg=round(float(neg / count), 2),
                                                      pos=round(float(pos / count), 2))
             return True

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -428,7 +428,7 @@ async def test_setting_ehub_sensor_values_via_mqtt_message(hass, mqtt_mock):
     }
 
     state = hass.states.get("sensor.ferroamp_dc_link_voltage")
-    assert state.state == "0"
+    assert state.state == "768.27"
     assert state.attributes == {
         'device_class': 'voltage',
         'friendly_name': 'EnergyHub DC Link Voltage',


### PR DESCRIPTION
Correct calculation of dc link voltage sensor state. Seems the values where reversed

fixes #364