### PR TITLE
Chore/dev container fixes

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,10 @@
 	"containerEnv": {
 		"TZ": "Europe/Stockholm"
 	},
-	"postCreateCommand": [".devcontainer/scripts/setup", "git config --global --add safe.directory ${containerWorkspaceFolder}"],
+	"postCreateCommand": [
+		".devcontainer/scripts/setup",
+		"git config --global --add safe.directory ${containerWorkspaceFolder}"
+	],
 	"customizations": {
 		"vscode": {
 			"extensions": [
@@ -47,11 +50,8 @@
 				"python.testing.pytestArgs": [
 					"."
 				],
-				"python.pythonPath": "/usr/bin/python3",
+				"python.defaultInterpreterPath": "/usr/local/bin/python3",
 				"python.analysis.autoSearchPaths": false,
-				"python.linting.pylintEnabled": true,
-				"python.linting.mypyEnabled": true,
-				"python.linting.enabled": true,
 				"[python]": {
 					"editor.defaultFormatter": "ms-python.black-formatter",
 					"editor.formatOnSave": true,

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,7 +28,8 @@
 				"ms-python.pylint",
 				"ms-python.vscode-pylance",
 				"ryanluker.vscode-coverage-gutters",
-				"ms-python.black-formatter"
+				"ms-python.black-formatter",
+				"redhat.vscode-yaml"
 			],
 			"settings": {
 				"python.testing.unittestArgs": [

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,29 @@
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
     hooks:
-    -   id: trailing-whitespace
-    -   id: end-of-file-fixer
-    -   id: check-yaml
-    -   id: check-added-large-files
--   repo: https://github.com/pycqa/isort
+      - id: check-added-large-files
+      - id: check-ast
+      - id: check-case-conflict
+      - id: check-docstring-first
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: check-yaml
+      - id: debug-statements
+      - id: detect-private-key
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+        args:
+          - --fix=lf
+      - id: requirements-txt-fixer
+        files: ^requirements.*\.txt$
+      - id: trailing-whitespace
+  - repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:
-    -   id: isort
+      - id: isort
         name: isort (python)
--   repo: https://github.com/psf/black
-    rev: 23.7.0
+  - repo: https://github.com/psf/black
+    rev: 23.11.0
     hooks:
-    - id: black
+      - id: black

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.defaultInterpreterPath": "/usr/local/bin/python3",
+}

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,6 +1,6 @@
 -r requirements.test.txt
 black==23.11.0
-isort==5.12.0
 flake8==6.1.0
 homeassistant==2023.7.3
+isort==5.12.0
 pre-commit==3.5.0

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,6 +1,6 @@
-# Strictly for tests
-pytest-homeassistant-custom-component==0.13.45
-janus==1.0.0
 # From our manifest.json for our custom component
 aiohttp_cors==0.7.0
+janus==1.0.0
 paho-mqtt==1.6.1
+# Strictly for tests
+pytest-homeassistant-custom-component==0.13.45


### PR DESCRIPTION
- fix [deprecated vscode settings](https://github.com/microsoft/vscode-python/wiki/Migration-to-Python-Tools-Extensions)
  - `python.linting.*`
  - `python.pythonPath`-> `python.defaultInterpreterPath`
    - vscode should hopefully pick correct interpreter from devcontainer now so that pylance can do it's thing 
- add yaml extension for linting and formatting
- upgrade pre-commit hooks
  - add some more checks
    - fix requirements*.txt files 