### PR TITLE
chore: fix race condition in postCreateCommand

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,8 +19,7 @@
 		"TZ": "Europe/Stockholm"
 	},
 	"postCreateCommand": [
-		".devcontainer/scripts/setup",
-		"git config --global --add safe.directory ${containerWorkspaceFolder}"
+		".devcontainer/scripts/setup"
 	],
 	"customizations": {
 		"vscode": {

--- a/.devcontainer/scripts/setup
+++ b/.devcontainer/scripts/setup
@@ -1,11 +1,9 @@
 #!/usr/bin/env bash
 
-set -e
-
-cd "$(dirname "$0")/../"
-
+set -ex
 # install development dependencies
-python3 -m pip install -r ../requirements.dev.txt
+python3 -m pip install -r requirements.dev.txt
 
 # install pre-commit git hooks
+git config --global --add safe.directory $(pwd)
 pre-commit install


### PR DESCRIPTION
avoids race condition on devcontainer creation by using postCreateCommand as these are run in parallel

- [x] makes sure `git config --global --add safe.directory` is called before any other git operations