### PR TITLE
chore(vscode): prompt for remote debug host

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,14 +21,34 @@
             "name": "Python: Attach Remote",
             "type": "python",
             "request": "attach",
-            "port": 5678,
-            "host": "homeassistant.local",
+            "host": "${input:remoteDebugHost}",
+            "port": "${input:remoteDebugPort}",
             "pathMappings": [
                 {
                     "localRoot": "${workspaceFolder}",
-                    "remoteRoot": "/usr/src/homeassistant"
+                    "remoteRoot": "${input:remoteRootDirectory}",
                 }
-            ]
+            ],
         }
+    ],
+    "inputs": [
+        {
+            "id": "remoteDebugHost",
+            "description": "Remote Home assistant host",
+            "type": "promptString",
+            "default": "homeassistant.local",
+        },
+        {
+            "id": "remoteDebugPort",
+            "description": "Remote PDB port",
+            "type": "promptString",
+            "default": "5678",
+        },
+        {
+            "id": "remoteRootDirectory",
+            "description": "Remote Home assistant root path (path of directory containing custom_components directory)",
+            "type": "promptString",
+            "default": "/config",
+        },
     ]
 }


### PR DESCRIPTION
make remote debug configuration interactive for easier debugging of remote server

prompt for

- [x] remote host
- [x] remote pdb port
- [x] remote ha root directory   

![image](https://github.com/henricm/ha-ferroamp/assets/10961167/ef219261-443b-48ca-9e5b-bc53a6dbb4b3)
