### PR TITLE
fix(sensor): do not log warning if sensor is not present

### DIFF
--- a/custom_components/ferroamp/sensor.py
+++ b/custom_components/ferroamp/sensor.py
@@ -1071,14 +1071,15 @@ class EnergyFerroampSensor(FloatValFerroampSensor):
         )
 
     def add_event(self, event):
-        if self.get_float_value(event) > 0:
-            super().add_event(event)
-        else:
-            _LOGGER.info(
-                "%s value %s seems to be zero. Ignoring",
-                self.entity_id,
-                self.get_value(event),
-            )
+        if not self.check_presence or self.present(event):
+            if self.get_float_value(event) > 0:
+                super().add_event(event)
+            else:
+                _LOGGER.info(
+                    "%s value %s seems to be zero. Ignoring",
+                    self.entity_id,
+                    self.get_value(event),
+                )
 
     def update_state_from_events(self, events):
         temp = None


### PR DESCRIPTION
- [x] do not log warnings in energy sensor when sensor data is not present in event

If sensor data is missing in event, `EnergyFerroampSensor` will write a warning to log to on every update, even if `check_presence=True`

The reason for this behaviour is that being that the `check_presence` check is done in the base class.

The issue is fixed by adding an additional check in `EnergyFerroampSensor`.

This fix applies to all `EnergyFerroampSensor` with `check_presence=True`
 - `Battery Energy Produced`
 - `Battery Energy Consumed`


fixes #405 





