### PR TITLE
chore: await hass.config_entries.async_forward_entry_setups

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,8 +29,9 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-    rev: v9.8.0
+    rev: v9.18.0
     hooks:
       - id: commitlint
         stages: [commit-msg]
         additional_dependencies: ["@commitlint/config-conventional"]
+        language_version: "22.10.0"

--- a/custom_components/ferroamp/const.py
+++ b/custom_components/ferroamp/const.py
@@ -1,4 +1,5 @@
 """Constants for Ferroamp"""
+
 import re
 
 CONF_INTERVAL = "interval"
@@ -15,6 +16,8 @@ TOPIC_ESM = "data/esm"
 TOPIC_CONTROL_REQUEST = "control/request"
 TOPIC_CONTROL_RESPONSE = "control/response"
 TOPIC_CONTROL_RESULT = "control/result"
+
+PLATFORMS = ["sensor"]
 
 EHUB = "ehub"
 EHUB_NAME = "EnergyHub"


### PR DESCRIPTION
Calling hass.config_entries.async_forward_entry_setup is deprecated and will be removed in Home Assistant 2025.6

Fixed issue with commitlint not working on node 23