### PR TITLE
ci: add conventional changelog configuration 

### DIFF
--- a/.github/conventional-changelog.js
+++ b/.github/conventional-changelog.js
@@ -1,0 +1,15 @@
+'use strict'
+const config = require('conventional-changelog-conventionalcommits');
+
+module.exports = config({
+    "types": [
+        {"type": "feat", "section": "Features"},
+        {"type": "fix", "section": "Bug Fixes"},
+        {"type": "docs", "section": "Documentation"},
+        {"type": "chore", "section": "Other Changes"},
+        {"type": "style", "section": "Other Changes"},
+        {"type": "refactor", "section": "Other Changes"},
+        {"type": "perf", "section": "Other Changes"},
+        {"type": "test", "section": "Other Changes"}
+    ]
+})

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
         with:
           github-token: ${{ secrets.github_token }}
           output-file: "false"
-          preset: conventionalcommits
+          config-file-path: "./.github/conventional-config.js"
           version-file: "custom_components/ferroamp/manifest.json"
           pre-changelog-generation: "./.github/scripts/tagname.js"
 


### PR DESCRIPTION
### Pull Request Description

**Title:** ci: add conventional changelog configuration

**Description:**
This pull request introduces a custom configuration for the conventional changelog, enabling us to define specific types and their respective sections more effectively. Additionally, it updates the GitHub Actions workflow to utilize the newly specified configuration file path rather than the default preset, enhancing the changelog generation process. These changes aim to improve the clarity and organization of commit messages within the generated changelogs, ultimately leading to better project documentation and version history tracking. 

**Changes Included:**
- Custom configuration for the conventional changelog.
- Updated GitHub Actions workflow to reference the new configuration path.

By merging this PR, we can achieve more structured and comprehensible changelogs for our project.