### PR TITLE
chore(deps): update Home Assistant and related dependencies

### DIFF
--- a/.github/workflows/pythonpackage.yaml
+++ b/.github/workflows/pythonpackage.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Ferroamp MQTT support sends updates to these topics:
  * extapi/data/esm (interval 60s)
 
 ## Prerequisites
-- Home assistant `2024.6.x`
+- Home assistant `2024.12.x`
 - Enable Ferroamp MQTT by contacting [Ferroamp Support](https://ferroamp.com/sv/kontakt/) to get the username and password for your Energy MQTT broker.
 -  Add Home assistant [MQTT integration](https://www.home-assistant.io/integrations/mqtt/) and set the broker to your Ferroamp Energy IP and configure it with your username and password received from Ferroamp (or setup a bridge-connection if you already have an MQTT-server, see the `Configuring Bridges`-section in the [Mosquitto documentation](https://mosquitto.org/man/mosquitto-conf-5.html)).
 

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,4 @@
 {
   "name": "Ferroamp Sensors",
-  "homeassistant": "2024.6.0"
+  "homeassistant": "2024.12.0"
 }

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -3,6 +3,6 @@ black==25.1.0
 colorlog==6.9.0
 debugpy
 flake8==7.1.1
-homeassistant==2024.6.0
+homeassistant==2024.12.0
 isort==6.0.0
 pre-commit==4.1.0

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -3,4 +3,4 @@ aiohttp_cors==0.7.0
 janus==2.0.0
 paho-mqtt==1.6.1
 # Strictly for tests
-pytest-homeassistant-custom-component==0.13.132
+pytest-homeassistant-custom-component==0.13.190


### PR DESCRIPTION
Updates Home Assistant to version 2024.12.0 in multiple files, ensuring 
compatibility with the latest features and fixes. Adjusts the Python version 
in CI configuration to 3.13 for improved performance. Updates the version 
of `pytest-homeassistant-custom-component` to 0.13.190 to leverage the 
latest testing enhancements. Modifies README to reflect the new 
Home Assistant version requirements.