### PR TITLE
chore: remove aiohttp_cors from test requirements

### DIFF
--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,5 +1,4 @@
 # From our manifest.json for our custom component
-aiohttp_cors==0.7.0
 janus==2.0.0
 # Strictly for tests
 pytest-homeassistant-custom-component==0.13.190


### PR DESCRIPTION
This change removes the aiohttp_cors dependency from the 
test requirements. It is a transitive dependency from HA core. This helps to reduce potential conflicts 
and improve the clarity of dependencies.