### PR TITLE
fix: set asyncio default fixture loop scope to function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ testpaths = ["tests"]
 norecursedirs = [".git"]
 addopts = ["--strict-markers", "--cov=custom_components"]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 
 [tool.isort]
 # https://github.com/timothycrosley/isort


### PR DESCRIPTION
Update the `asyncio_default_fixture_loop_scope` in the
`pyproject.toml` file to "function" to ensure that
fixtures using asyncio have the correct scope for testing.
This improves test reliability and isolates test cases
more effectively.