### PR TITLE
fix: skip disabled sensors in add_event to prevent memory leak

### DIFF
--- a/custom_components/ferroamp/sensor.py
+++ b/custom_components/ferroamp/sensor.py
@@ -1666,11 +1666,16 @@ class KeyedFerroampSensor(FerroampSensor):
 
     def add_event(self, event: MqttEvent) -> None:
         """Add MQTT event to processing queue."""
+        # Disabled entities never receive `async_added_to_hass`, so `_added`
+        # stays False forever. Skipping here prevents `self.events` from
+        # accumulating MQTT payloads indefinitely (issue #888).
+        if not self._added:
+            return
         if not self.check_presence or self.present(event):
             self.events.append(event)
         now = datetime.now()
         delta = (now - self.updated).total_seconds()
-        if delta > self._interval and self._added:
+        if delta > self._interval:
             self.process_events(now)
 
     def process_events(self, now: datetime) -> None:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1840,6 +1840,20 @@ async def test_base_class_update_state_from_events():
         sensor.update_state_from_events([{}])
 
 
+async def test_disabled_sensor_does_not_accumulate_events():
+    """Regression for issue #888: disabled sensors must not buffer MQTT events.
+
+    Disabled entities never receive ``async_added_to_hass``, so ``_added``
+    stays False. ``add_event`` previously appended to ``self.events`` before
+    checking ``_added``, causing unbounded growth.
+    """
+    sensor = KeyedFerroampSensor("test", "prefix", "key", "", "", "", "", 20, "a")
+    assert sensor._added is False
+    for _ in range(1000):
+        sensor.add_event({"key": 1})
+    assert sensor.events == []
+
+
 async def test_control_command(hass, mqtt_mock):
     config_entry = create_config()
     config_entry.add_to_hass(hass)


### PR DESCRIPTION
Closes #888.

## Cause

Disabled entities never receive `async_added_to_hass`, so `_added` stays False forever. `KeyedFerroampSensor.add_event` previously appended to `self.events` before checking `_added`, while `process_events` (which clears the list) was gated on `_added`. The MQTT handler at `sensor.py:1058-1061` calls `add_event` for every registered sensor regardless of enabled state, so disabled sensors leaked roughly 45 nested dicts per second on the 1 Hz EHUB topic — ~1,350 dicts per 30 s window.

## Fix

Early-return when `not self._added`. The redundant `_added` check on the `process_events` gate is removed since the early return covers it. All subclass overrides (`StringValFerroampSensor`, the energy phase variants) delegate through this method, so one fix covers every path.

## Side effect

Events arriving between sensor instantiation and `async_added_to_hass` completion are now dropped instead of buffered. In practice that's at most 1–2 events, immediately replaced by the next interval tick — negligible vs. the unbounded leak it stops.

## Test plan

- [x] New regression test feeding 1000 events with `_added=False` — asserts `events == []`
- [x] Full suite: 107/107 passing, coverage 98.29%