### PR TITLE
feat(sensor): add decoded fault state sensors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,8 +31,9 @@ pre-commit run --all-files
 
 - `custom_components/ferroamp/__init__.py` - Entry point; sets up MQTT subscriptions for battery control services (`charge`, `discharge`, `autocharge`)
 - `custom_components/ferroamp/sensor.py` - Main sensor platform; subscribes to MQTT topics and creates sensors dynamically
+- `custom_components/ferroamp/fault_codes.py` - Internal `IntFlag` models and helpers for decoded ESO/SSO fault state sensors
 - `custom_components/ferroamp/config_flow.py` - UI-based configuration for the integration
-- `custom_components/ferroamp/const.py` - Constants including MQTT topics, fault codes, and regex patterns
+- `custom_components/ferroamp/const.py` - Constants including MQTT topics, legacy fault code messages, and regex patterns
 
 ### Sensor Hierarchy
 
@@ -43,7 +44,7 @@ The `sensor.py` contains a hierarchy of sensor classes:
   - `ThreePhaseFerroampSensor` - Aggregates L1/L2/L3 phases
   - `SinglePhaseFerroampSensor` - Individual phase values
   - `EnergyFerroampSensor` - Energy accumulation with kWh conversion
-  - Specialized: `BatteryFerroampSensor`, `TemperatureFerroampSensor`, `FaultcodeFerroampSensor`
+  - Specialized: `BatteryFerroampSensor`, `TemperatureFerroampSensor`, `FaultcodeFerroampSensor`, `DecodedFaultcodeFerroampSensor`
 
 ### MQTT Topic Structure
 
@@ -53,6 +54,14 @@ Sensors subscribe to topics under a configurable prefix (default: `extapi`):
 - `extapi/data/eso` - Battery system data (5s interval)
 - `extapi/data/esm` - Battery module data (60s interval)
 - `extapi/control/*` - Battery control request/response
+
+### Fault Codes
+
+ESO and SSO devices expose the original `Faultcode` sensor for backwards compatibility. This legacy sensor parses the MQTT value as a decimal `uint16` bitmask and exposes mapped messages as attributes.
+
+New `Fault State` sensors are added beside the legacy sensors for ESO and SSO devices. They parse `faultcode.val` as a decimal `uint16` bitmask, model known bits with `IntFlag` classes in `fault_codes.py`, and expose a human-readable PascalCase state that is visible in Home Assistant history, for example `DcLinkVoltageTooHigh`, `InternalTemperatureLimit|PowerLimiting`, or `Unknown0x0200` for undocumented bits. Supporting attributes include `raw_value`, `value_hex`, `active_messages`, and `unknown_bits`.
+
+SSO `PvGroundFault` is mapped to bit `0x0001` based on Ferroamp support feedback. Keep the SSO mapping in `const.py` and `fault_codes.py` aligned for this bit so the legacy `Faultcode` and decoded `Fault State` sensors report the same PV ground fault.
 
 ### Event Processing
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,24 @@ This integration will add lots of sensors for the installed hardware with the pr
 
 I'm also still figuring out what some of the sensors actually are, since the Ferroamp API documentation still seems to be incomplete in some areas.
 
+## Fault codes
+
+ESO and SSO devices have two fault-related sensors:
+
+- `Faultcode` - the original/raw faultcode sensor, kept for backwards compatibility.
+- `Fault State` - a decoded diagnostic sensor intended to be easier to read in Home Assistant history.
+
+The `Fault State` sensor parses the API value as a decimal `uint16` bitmask and exposes joined PascalCase fault names as the sensor state. Examples:
+
+| Device | Raw value | Fault State |
+|--------|-----------|-------------|
+| ESO | `32` | `DcLinkVoltageTooHigh` |
+| ESO | `544` | `DcLinkVoltageTooHigh\|Unknown0x0200` |
+| SSO | `1` | `PvGroundFault` |
+| SSO | `1088` | `InternalTemperatureLimit\|PowerLimiting` |
+
+Unknown or undocumented bits are shown as `Unknown0xNNNN`. The sensor also includes attributes with the raw value, hexadecimal value, active messages and unknown bits.
+
 ## Upgrading from a version before config flow was implemented
 
 1. Remove the integration configuration. i.e this

--- a/custom_components/ferroamp/const.py
+++ b/custom_components/ferroamp/const.py
@@ -42,9 +42,9 @@ for trouble shooting the battery, or call Ferroamp Support.""",
 ]
 
 FAULT_CODES_SSO = [
-    "Unknown fault code",
-    "Unknown fault code",
     "Error, PV ground fault",
+    "Unknown fault code",
+    "Unknown fault code",
     "Error, internal voltage unbalance",
     "Warning, PV undervoltage, not possible to sustain MPPT operation",
     "Warning, DC grid voltage too high, SSO will not connect to DC grid",

--- a/custom_components/ferroamp/fault_codes.py
+++ b/custom_components/ferroamp/fault_codes.py
@@ -1,0 +1,143 @@
+"""Fault code helpers for Ferroamp bitmask values."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from enum import IntFlag
+
+
+class EsoFault(IntFlag):
+    """ESO fault bitmask values."""
+
+    PrechargeFailed = 0x0001
+    CanCommunication = 0x0002
+    SocLimitsInvalid = 0x0004
+    PowerLimitsInvalid = 0x0008
+    EmergencyStop = 0x0010
+    DcLinkVoltageTooHigh = 0x0020
+    BatteryAlarm = 0x0040
+    NonFerroampBattery = 0x0080
+
+
+class SsoFault(IntFlag):
+    """SSO fault bitmask values."""
+
+    PvGroundFault = 0x0001
+    # 0x0002 and 0x0004 are currently undocumented.
+    InternalVoltageUnbalance = 0x0008
+    PvUndervoltage = 0x0010
+    DcGridVoltageTooHigh = 0x0020
+    InternalTemperatureLimit = 0x0040
+    InternalPowerElectronicsFault = 0x0080
+    InternalRelayTestFault = 0x0100
+    MemoryError = 0x0200
+    PowerLimiting = 0x0400
+
+
+ESO_FAULT_DESCRIPTIONS: dict[EsoFault, str] = {
+    EsoFault.PrechargeFailed: (
+        "The pre-charge from battery to ESO is not reaching the voltage goal "
+        "prohibiting the closing of the relays."
+    ),
+    EsoFault.CanCommunication: "CAN communication issues between ESO and battery.",
+    EsoFault.SocLimitsInvalid: (
+        "This indicates that the SoC limits for the batteries are not configured "
+        "correctly, please contact Ferroamp Support for help."
+    ),
+    EsoFault.PowerLimitsInvalid: (
+        "This indicates that the power limits for the batteries are incorrect or "
+        "non-optimal."
+    ),
+    EsoFault.EmergencyStop: "On-site emergency stop has been triggered.",
+    EsoFault.DcLinkVoltageTooHigh: (
+        "The DC-link voltage in ESO is so high that it prevents operation."
+    ),
+    EsoFault.BatteryAlarm: (
+        "Indicates that the battery has an alarm or an error flag raised."
+    ),
+    EsoFault.NonFerroampBattery: (
+        "Not a fault, just an indication that Battery Manufacturer is not Ferroamp."
+    ),
+}
+
+SSO_FAULT_DESCRIPTIONS: dict[SsoFault, str] = {
+    SsoFault.PvGroundFault: "Error, PV ground fault",
+    SsoFault.InternalVoltageUnbalance: "Error, internal voltage unbalance",
+    SsoFault.PvUndervoltage: (
+        "Warning, PV undervoltage, not possible to sustain MPPT operation"
+    ),
+    SsoFault.DcGridVoltageTooHigh: (
+        "Warning, DC grid voltage too high, SSO will not connect to DC grid"
+    ),
+    SsoFault.InternalTemperatureLimit: (
+        "Warning, Limiting current due to internal temperature"
+    ),
+    SsoFault.InternalPowerElectronicsFault: "Error, Internal power electronics fault",
+    SsoFault.InternalRelayTestFault: (
+        "Error, Internal relay test circuit has detected a fault"
+    ),
+    SsoFault.MemoryError: (
+        "Error, Memory error, configuration parameters can not be read"
+    ),
+    SsoFault.PowerLimiting: (
+        "Warning, SSO is limiting power, either because of internal temperature "
+        "or DC grid voltage level"
+    ),
+}
+
+
+def parse_faultcode(value: str) -> int:
+    """Parse an extapi faultcode value as a decimal uint16 string."""
+    parsed = int(str(value).strip(), 10)
+    if parsed < 0 or parsed > 0xFFFF:
+        raise ValueError("faultcode is outside uint16 range")
+    return parsed
+
+
+def known_fault_mask(fault_type: type[IntFlag]) -> int:
+    """Return a mask containing all known flags for a fault type."""
+    mask = 0
+    for fault in fault_type:
+        mask |= fault.value
+    return mask
+
+
+def active_fault_names(value: int, fault_type: type[IntFlag]) -> list[str]:
+    """Return names for all known active faults."""
+    return [fault.name for fault in fault_type if value & fault.value == fault.value]
+
+
+def unknown_fault_bits(value: int, fault_type: type[IntFlag]) -> list[str]:
+    """Return unknown active bit masks as hexadecimal strings."""
+    unknown = value & ~known_fault_mask(fault_type)
+    bits = []
+    bit = 1
+    while unknown:
+        if unknown & bit:
+            bits.append(f"0x{bit:04X}")
+            unknown &= ~bit
+        bit <<= 1
+    return bits
+
+
+def format_fault_state(value: int, fault_type: type[IntFlag]) -> str:
+    """Format a fault bitmask as a Home Assistant state string."""
+    if value == 0:
+        return "Ok"
+
+    parts = active_fault_names(value, fault_type)
+    parts.extend(f"Unknown{bit}" for bit in unknown_fault_bits(value, fault_type))
+    return "|".join(parts) if parts else "Unknown"
+
+
+def active_fault_descriptions(
+    value: int,
+    fault_type: type[IntFlag],
+    descriptions: Mapping[IntFlag, str],
+) -> list[str]:
+    """Return descriptions for all known active faults."""
+    return [
+        descriptions[fault]
+        for fault in fault_type
+        if value & fault.value == fault.value and fault in descriptions
+    ]

--- a/custom_components/ferroamp/sensor.py
+++ b/custom_components/ferroamp/sensor.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from datetime import datetime
-from enum import Enum
+from enum import Enum, IntFlag
 import json
 import logging
 from typing import Any
@@ -30,7 +30,7 @@ from homeassistant.const import (
     UnitOfTemperature,
 )
 from homeassistant.core import callback
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.entity_registry import (
     EntityRegistry,
@@ -59,6 +59,16 @@ from .const import (
     TOPIC_ESM,
     TOPIC_ESO,
     TOPIC_SSO,
+)
+from .fault_codes import (
+    ESO_FAULT_DESCRIPTIONS,
+    SSO_FAULT_DESCRIPTIONS,
+    EsoFault,
+    SsoFault,
+    active_fault_descriptions,
+    format_fault_state,
+    parse_faultcode,
+    unknown_fault_bits,
 )
 from .mqtt_parser import (
     CommandParser,
@@ -1145,6 +1155,18 @@ async def async_setup_entry(
                     config_id,
                     model=model,
                 ),
+                DecodedFaultcodeFerroampSensor(
+                    "Fault State",
+                    device_id,
+                    "faultcode",
+                    device_id,
+                    device_name,
+                    interval,
+                    SsoFault,
+                    SSO_FAULT_DESCRIPTIONS,
+                    config_id,
+                    model=model,
+                ),
                 RelayStatusFerroampSensor(
                     "Relay Status",
                     device_id,
@@ -1250,6 +1272,17 @@ async def async_setup_entry(
                     device_name,
                     interval,
                     FAULT_CODES_ESO,
+                    config_id,
+                ),
+                DecodedFaultcodeFerroampSensor(
+                    "Fault State",
+                    device_id,
+                    "faultcode",
+                    device_id,
+                    device_name,
+                    interval,
+                    EsoFault,
+                    ESO_FAULT_DESCRIPTIONS,
                     config_id,
                 ),
                 RelayStatusFerroampSensor(
@@ -2600,7 +2633,7 @@ class FaultcodeFerroampSensor(KeyedFerroampSensor):
         if val is None:
             return False
         self._attr_native_value = val
-        x = int(val, 16)
+        x = parse_faultcode(val)
         if x == 0:
             self._attr_extra_state_attributes["0"] = "No errors"
         else:
@@ -2612,4 +2645,65 @@ class FaultcodeFerroampSensor(KeyedFerroampSensor):
                 self._attr_extra_state_attributes[f"{i + 1}"] = code
             elif f"{i + 1}" in self._attr_extra_state_attributes:
                 del self._attr_extra_state_attributes[f"{i + 1}"]
+        return True
+
+
+class DecodedFaultcodeFerroampSensor(KeyedFerroampSensor):
+    """Ferroamp decoded faultcode sensor using decimal bitmask parsing."""
+
+    def __init__(
+        self,
+        name: str,
+        entity_prefix: str,
+        key: str,
+        device_id: str,
+        device_name: str,
+        interval: int,
+        fault_type: type[IntFlag],
+        fault_descriptions: Mapping[IntFlag, str],
+        config_id: str | None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(
+            name,
+            entity_prefix,
+            key,
+            None,
+            "mdi:traffic-light",
+            device_id,
+            device_name,
+            interval,
+            config_id,
+            **kwargs,
+        )
+        self._attr_unique_id = f"{self.device_id}-fault_state"
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        self._fault_type = fault_type
+        self._fault_descriptions = fault_descriptions
+
+    def update_state_from_events(self, events: list[MqttEvent]) -> bool:
+        """Update state from events."""
+        val = last_string_value(events, self._state_key)
+        if val is None:
+            return False
+
+        try:
+            value = parse_faultcode(val)
+        except ValueError:
+            self._attr_native_value = "Invalid"
+            self._attr_extra_state_attributes = {"raw_value": val}
+            return True
+
+        self._attr_native_value = format_fault_state(value, self._fault_type)
+        self._attr_extra_state_attributes = {
+            "raw_value": val,
+            "value_hex": f"0x{value:04X}",
+            "active_messages": active_fault_descriptions(
+                value,
+                self._fault_type,
+                self._fault_descriptions,
+            ),
+            "unknown_bits": unknown_fault_bits(value, self._fault_type),
+        }
         return True

--- a/info.md
+++ b/info.md
@@ -10,6 +10,10 @@ This integration adds sensors for the [Ferroamp](https://ferroamp.com) EnergyHub
 2. Set a name for the integration as well as the MQTT-prefix where updates are sent (default values are probably fine for a standard-setup but if a bridge-connection is used the MQTT-topics can be re-mapped)
 3. Wait for all the devices to become present (EnergyHub, SSO's, ESOs and ESMs depending on your setup. Be patient since ESMs are only updated every 60 seconds.)
 
+## Fault codes
+
+ESO and SSO devices expose both the original raw `Faultcode` sensor and a decoded `Fault State` diagnostic sensor. `Fault State` parses the API value as a decimal bitmask and shows readable states such as `DcLinkVoltageTooHigh`, `PvGroundFault` or `InternalTemperatureLimit|PowerLimiting`. Unknown bits are shown as `Unknown0xNNNN`.
+
 ## Update interval
 
 To avoid too much data into home assistant, we only update sensors with new values every 30 second (average values are calculated where appropriate). This interval can be configured in the options of the integration.

--- a/tests/test_fault_codes.py
+++ b/tests/test_fault_codes.py
@@ -1,0 +1,47 @@
+import pytest
+
+from custom_components.ferroamp.fault_codes import (
+    ESO_FAULT_DESCRIPTIONS,
+    SSO_FAULT_DESCRIPTIONS,
+    EsoFault,
+    SsoFault,
+    active_fault_descriptions,
+    active_fault_names,
+    format_fault_state,
+    parse_faultcode,
+    unknown_fault_bits,
+)
+
+
+def test_parse_faultcode_as_decimal_uint16_string():
+    assert parse_faultcode("32") == 32
+    assert parse_faultcode(" 544 ") == 544
+
+
+@pytest.mark.parametrize("value", ["-1", "65536", "not-a-number"])
+def test_parse_faultcode_rejects_invalid_values(value):
+    with pytest.raises(ValueError):
+        parse_faultcode(value)
+
+
+def test_format_eso_fault_state_with_unknown_bits():
+    assert format_fault_state(0, EsoFault) == "Ok"
+    assert format_fault_state(32, EsoFault) == "DcLinkVoltageTooHigh"
+    assert format_fault_state(544, EsoFault) == "DcLinkVoltageTooHigh|Unknown0x0200"
+    assert active_fault_names(544, EsoFault) == ["DcLinkVoltageTooHigh"]
+    assert active_fault_descriptions(544, EsoFault, ESO_FAULT_DESCRIPTIONS) == [
+        "The DC-link voltage in ESO is so high that it prevents operation."
+    ]
+    assert unknown_fault_bits(544, EsoFault) == ["0x0200"]
+
+
+def test_format_sso_fault_state():
+    assert format_fault_state(1, SsoFault) == "PvGroundFault"
+    assert (
+        format_fault_state(1088, SsoFault) == "InternalTemperatureLimit|PowerLimiting"
+    )
+    assert active_fault_descriptions(1088, SsoFault, SSO_FAULT_DESCRIPTIONS) == [
+        "Warning, Limiting current due to internal temperature",
+        "Warning, SSO is limiting power, either because of internal temperature "
+        "or DC grid voltage level",
+    ]

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1029,7 +1029,7 @@ async def test_setting_eso_sensor_values_via_mqtt_message(hass, mqtt_mock):
             "ubat": {"val": 622.601},
             "ibat": {"val": 1.5700000000000001},
             "relaystatus": {"val": "0"},
-            "faultcode": {"val": "80"},
+            "faultcode": {"val": "128"},
             "ts": {"val": "2021-03-07T19:21:04UTC"},
             "id": {"val": "1"},
             "wbatprod": {"val": 2465106122063}
@@ -1098,7 +1098,7 @@ async def test_setting_eso_sensor_values_via_mqtt_message(hass, mqtt_mock):
     }
 
     state = hass.states.get("sensor.ferroamp_eso_1_faultcode")
-    assert state.state == "80"
+    assert state.state == "128"
     assert state.attributes == {
         "friendly_name": "ESO 1 Faultcode",
         "icon": "mdi:traffic-light",
@@ -1137,7 +1137,7 @@ async def test_relay_status_open(hass, mqtt_mock):
             "ubat": {"val": 622.601},
             "ibat": {"val": 1.5700000000000001},
             "relaystatus": {"val": "1"},
-            "faultcode": {"val": "80"},
+            "faultcode": {"val": "128"},
             "ts": {"val": "2021-03-07T19:21:04UTC"},
             "id": {"val": "1"},
             "wbatprod": {"val": 2465106122063}
@@ -1163,7 +1163,7 @@ async def test_relay_status_precharge(hass, mqtt_mock):
             "ubat": {"val": 622.601},
             "ibat": {"val": 1.5700000000000001},
             "relaystatus": {"val": "2"},
-            "faultcode": {"val": "80"},
+            "faultcode": {"val": "128"},
             "ts": {"val": "2021-03-07T19:21:04UTC"},
             "id": {"val": "1"},
             "wbatprod": {"val": 2465106122063}
@@ -1426,6 +1426,96 @@ async def test_migrate_old_sso_entities(hass, mqtt_mock):
     }
 
 
+async def test_decoded_eso_fault_state_uses_decimal_bitmask(hass, mqtt_mock):
+    config_entry = create_config()
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    topic = "extapi/data/eso"
+    async_fire_mqtt_message(
+        hass,
+        topic,
+        """{
+                "soc": {"val": 48.100003999999998},
+                "temp": {"val": 20.379000000000001},
+                "wbatcons": {"val": 2213535479518},
+                "ubat": {"val": 622.601},
+                "ibat": {"val": 1.5700000000000001},
+                "relaystatus": {"val": "0"},
+                "faultcode": {"val": "544"},
+                "ts": {"val": "2021-03-07T19:21:04UTC"},
+                "id": {"val": "1"},
+                "wbatprod": {"val": 2465106122063}
+            }""",
+    )
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    state = hass.states.get("sensor.ferroamp_eso_1_fault_state")
+    assert state.state == "DcLinkVoltageTooHigh|Unknown0x0200"
+    assert state.attributes["friendly_name"] == "ESO 1 Fault State"
+    assert state.attributes["icon"] == "mdi:traffic-light"
+    assert state.attributes["raw_value"] == "544"
+    assert state.attributes["value_hex"] == "0x0220"
+    assert state.attributes["active_messages"] == [
+        "The DC-link voltage in ESO is so high that it prevents operation."
+    ]
+    assert state.attributes["unknown_bits"] == ["0x0200"]
+
+
+async def test_decoded_sso_fault_state_uses_decimal_bitmask(hass, mqtt_mock):
+    config_entry = create_config()
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    topic = "extapi/data/sso"
+    async_fire_mqtt_message(
+        hass,
+        topic,
+        """{
+                "relaystatus": {"val": "0"},
+                "temp": {"val": "6.482"},
+                "wpv": {"val": "843516404273"},
+                "ts": {"val": "2021-03-08T08:22:42UTC"},
+                "udc": {"val": "769.872"},
+                "faultcode": {"val": "1088"},
+                "ipv": {"val": "4.826"},
+                "upv": {"val": "653.012"},
+                "id": {"val": "12345678"}
+            }""",
+    )
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    state = hass.states.get("sensor.ferroamp_sso_12345678_fault_state")
+    assert state.state == "InternalTemperatureLimit|PowerLimiting"
+    assert state.attributes["friendly_name"] == "SSO 12345678 Fault State"
+    assert state.attributes["raw_value"] == "1088"
+    assert state.attributes["value_hex"] == "0x0440"
+    assert state.attributes["unknown_bits"] == []
+
+    async_fire_mqtt_message(
+        hass,
+        topic,
+        """{
+                "relaystatus": {"val": "0"},
+                "temp": {"val": "6.482"},
+                "wpv": {"val": "843516404273"},
+                "ts": {"val": "2021-03-08T08:22:47UTC"},
+                "udc": {"val": "769.872"},
+                "faultcode": {"val": "1"},
+                "ipv": {"val": "4.826"},
+                "upv": {"val": "653.012"},
+                "id": {"val": "12345678"}
+            }""",
+    )
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    state = hass.states.get("sensor.ferroamp_sso_12345678_fault_state")
+    assert state.state == "PvGroundFault"
+    assert state.attributes["active_messages"] == ["Error, PV ground fault"]
+
+
 async def test_sso_fault_codes(hass, mqtt_mock):
     config_entry = create_config()
     config_entry.add_to_hass(hass)
@@ -1467,7 +1557,7 @@ async def test_sso_fault_codes(hass, mqtt_mock):
                 "wpv": {"val": "843516404273"},
                 "ts": {"val": "2021-03-08T08:22:42UTC"},
                 "udc": {"val": "769.872"},
-                "faultcode": {"val": "4"},
+                "faultcode": {"val": "1"},
                 "ipv": {"val": "4.826"},
                 "upv": {"val": "653.012"},
                 "id": {"val": "12345678"}
@@ -1476,11 +1566,11 @@ async def test_sso_fault_codes(hass, mqtt_mock):
     await hass.async_block_till_done(wait_background_tasks=True)
 
     state = hass.states.get("sensor.ferroamp_sso_12345678_faultcode")
-    assert state.state == "4"
+    assert state.state == "1"
     assert state.attributes == {
         "friendly_name": "SSO 12345678 Faultcode",
         "icon": "mdi:traffic-light",
-        "3": "Error, PV ground fault",
+        "1": "Error, PV ground fault",
     }
 
     async_fire_mqtt_message(
@@ -1517,7 +1607,7 @@ async def test_sso_fault_codes(hass, mqtt_mock):
                 "wpv": {"val": "843516404273"},
                 "ts": {"val": "2021-03-08T08:22:42UTC"},
                 "udc": {"val": "769.872"},
-                "faultcode": {"val": "10"},
+                "faultcode": {"val": "16"},
                 "ipv": {"val": "4.826"},
                 "upv": {"val": "653.012"},
                 "id": {"val": "12345678"}
@@ -1526,7 +1616,7 @@ async def test_sso_fault_codes(hass, mqtt_mock):
     await hass.async_block_till_done(wait_background_tasks=True)
 
     state = hass.states.get("sensor.ferroamp_sso_12345678_faultcode")
-    assert state.state == "10"
+    assert state.state == "16"
     assert state.attributes == {
         "friendly_name": "SSO 12345678 Faultcode",
         "icon": "mdi:traffic-light",
@@ -1542,7 +1632,7 @@ async def test_sso_fault_codes(hass, mqtt_mock):
                 "wpv": {"val": "843516404273"},
                 "ts": {"val": "2021-03-08T08:22:42UTC"},
                 "udc": {"val": "769.872"},
-                "faultcode": {"val": "20"},
+                "faultcode": {"val": "32"},
                 "ipv": {"val": "4.826"},
                 "upv": {"val": "653.012"},
                 "id": {"val": "12345678"}
@@ -1551,7 +1641,7 @@ async def test_sso_fault_codes(hass, mqtt_mock):
     await hass.async_block_till_done(wait_background_tasks=True)
 
     state = hass.states.get("sensor.ferroamp_sso_12345678_faultcode")
-    assert state.state == "20"
+    assert state.state == "32"
     assert state.attributes == {
         "friendly_name": "SSO 12345678 Faultcode",
         "icon": "mdi:traffic-light",
@@ -1567,7 +1657,7 @@ async def test_sso_fault_codes(hass, mqtt_mock):
                 "wpv": {"val": "843516404273"},
                 "ts": {"val": "2021-03-08T08:22:42UTC"},
                 "udc": {"val": "769.872"},
-                "faultcode": {"val": "40"},
+                "faultcode": {"val": "64"},
                 "ipv": {"val": "4.826"},
                 "upv": {"val": "653.012"},
                 "id": {"val": "12345678"}
@@ -1576,7 +1666,7 @@ async def test_sso_fault_codes(hass, mqtt_mock):
     await hass.async_block_till_done(wait_background_tasks=True)
 
     state = hass.states.get("sensor.ferroamp_sso_12345678_faultcode")
-    assert state.state == "40"
+    assert state.state == "64"
     assert state.attributes == {
         "friendly_name": "SSO 12345678 Faultcode",
         "icon": "mdi:traffic-light",
@@ -1592,7 +1682,7 @@ async def test_sso_fault_codes(hass, mqtt_mock):
                 "wpv": {"val": "843516404273"},
                 "ts": {"val": "2021-03-08T08:22:42UTC"},
                 "udc": {"val": "769.872"},
-                "faultcode": {"val": "80"},
+                "faultcode": {"val": "128"},
                 "ipv": {"val": "4.826"},
                 "upv": {"val": "653.012"},
                 "id": {"val": "12345678"}
@@ -1601,7 +1691,7 @@ async def test_sso_fault_codes(hass, mqtt_mock):
     await hass.async_block_till_done(wait_background_tasks=True)
 
     state = hass.states.get("sensor.ferroamp_sso_12345678_faultcode")
-    assert state.state == "80"
+    assert state.state == "128"
     assert state.attributes == {
         "friendly_name": "SSO 12345678 Faultcode",
         "icon": "mdi:traffic-light",
@@ -1617,7 +1707,7 @@ async def test_sso_fault_codes(hass, mqtt_mock):
                 "wpv": {"val": "843516404273"},
                 "ts": {"val": "2021-03-08T08:22:42UTC"},
                 "udc": {"val": "769.872"},
-                "faultcode": {"val": "100"},
+                "faultcode": {"val": "256"},
                 "ipv": {"val": "4.826"},
                 "upv": {"val": "653.012"},
                 "id": {"val": "12345678"}
@@ -1626,7 +1716,7 @@ async def test_sso_fault_codes(hass, mqtt_mock):
     await hass.async_block_till_done(wait_background_tasks=True)
 
     state = hass.states.get("sensor.ferroamp_sso_12345678_faultcode")
-    assert state.state == "100"
+    assert state.state == "256"
     assert state.attributes == {
         "friendly_name": "SSO 12345678 Faultcode",
         "icon": "mdi:traffic-light",
@@ -1642,7 +1732,7 @@ async def test_sso_fault_codes(hass, mqtt_mock):
                 "wpv": {"val": "843516404273"},
                 "ts": {"val": "2021-03-08T08:22:42UTC"},
                 "udc": {"val": "769.872"},
-                "faultcode": {"val": "200"},
+                "faultcode": {"val": "512"},
                 "ipv": {"val": "4.826"},
                 "upv": {"val": "653.012"},
                 "id": {"val": "12345678"}
@@ -1651,7 +1741,7 @@ async def test_sso_fault_codes(hass, mqtt_mock):
     await hass.async_block_till_done(wait_background_tasks=True)
 
     state = hass.states.get("sensor.ferroamp_sso_12345678_faultcode")
-    assert state.state == "200"
+    assert state.state == "512"
     assert state.attributes == {
         "friendly_name": "SSO 12345678 Faultcode",
         "icon": "mdi:traffic-light",
@@ -1667,7 +1757,7 @@ async def test_sso_fault_codes(hass, mqtt_mock):
                 "wpv": {"val": "843516404273"},
                 "ts": {"val": "2021-03-08T08:22:42UTC"},
                 "udc": {"val": "769.872"},
-                "faultcode": {"val": "400"},
+                "faultcode": {"val": "1024"},
                 "ipv": {"val": "4.826"},
                 "upv": {"val": "653.012"},
                 "id": {"val": "12345678"}
@@ -1676,7 +1766,7 @@ async def test_sso_fault_codes(hass, mqtt_mock):
     await hass.async_block_till_done(wait_background_tasks=True)
 
     state = hass.states.get("sensor.ferroamp_sso_12345678_faultcode")
-    assert state.state == "400"
+    assert state.state == "1024"
     assert state.attributes == {
         "friendly_name": "SSO 12345678 Faultcode",
         "icon": "mdi:traffic-light",


### PR DESCRIPTION
Add human-readable fault state sensors alongside the existing raw faultcode sensors.

- model ESO and SSO faultcodes with IntFlag bitmasks
- parse extapi faultcodes as decimal uint16 values
- expose joined PascalCase fault names as sensor state for HA history
- map SSO PvGroundFault to 0x0001 for decoded fault states
- align the legacy SSO Faultcode PV ground mapping with 0x0001
- include hex value, messages and unknown bits as attributes
- keep existing Faultcode sensor entities for backwards compatibility
- document the new Fault State sensors
- add tests for fault decoding and new sensor states

#### SSO fault codes still undocumented

It would be great to get confirmation from Ferroamp that the SSO codes are correct as they are undocumented in their API documentation.

#### Examples in Home assistant UI

This change will make it easier to read out the different fault codes and give a better overview when displaying history of fault codes and what their meaning is.

<img width="586" height="598" alt="FaultState1" src="https://github.com/user-attachments/assets/bc2c20bd-5e88-4355-b947-0781071b452d" />
<img width="570" height="443" alt="FaultState2" src="https://github.com/user-attachments/assets/6c9d0d06-df4d-4e6d-ab90-25061e48d464" />
<img width="582" height="603" alt="FaultState3" src="https://github.com/user-attachments/assets/f307da1a-da3a-4aa2-8c29-8c46c52c28bc" />

<img width="580" height="595" alt="FaultState-Attributes" src="https://github.com/user-attachments/assets/c02db1e0-9251-4982-a542-3375111864e9" />
