### PR TITLE
chore(deps): move to Python 3.14 and unblock Dependabot

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "henricm/ha-ferroamp",
-	"image": "mcr.microsoft.com/devcontainers/python:3.12",
+	"image": "mcr.microsoft.com/devcontainers/python:3.14",
 	"forwardPorts": [
 		8123,
 		5678

--- a/.github/workflows/pythonpackage.yaml
+++ b/.github/workflows/pythonpackage.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.13"]
+        python-version: ["3.14"]
 
     steps:
       - uses: actions/checkout@v7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,4 +75,4 @@ The project uses commitlint with conventional commits format. Commits must follo
 
 Tests use `pytest-homeassistant-custom-component` which provides Home Assistant test fixtures. The `conftest.py` enables custom integration loading and mocks persistent notifications.
 
-Required Python version: 3.13+
+Required Python version: 3.14+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-ferroamp"
-requires-python = ">=3.13, <4.0"
+requires-python = ">=3.14, <4.0"
 
 [tool.coverage.run]
 source = ["custom_components"]

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -3,6 +3,5 @@ black==26.5.1
 colorlog==6.12.0
 debugpy
 flake8==7.3.0
-homeassistant==2024.12.0
 isort==8.0.1
 pre-commit==4.6.1

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,4 +1,4 @@
 # From our manifest.json for our custom component
 janus==2.0.0
 # Strictly for tests
-pytest-homeassistant-custom-component==0.13.190
+pytest-homeassistant-custom-component==0.13.348

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -92,6 +92,7 @@ async def test_service_charge(hass, mqtt_mock):
                 '{"transId": "00000000-0000-0000-0000-000000000001", "cmd": {"name": "charge", "arg": 2000}}',
                 0,
                 False,
+                message_expiry_interval=None,
             )
         ]
     )
@@ -123,6 +124,7 @@ async def test_service_charge_default_power(hass, mqtt_mock):
                 '{"transId": "00000000-0000-0000-0000-000000000001", "cmd": {"name": "charge", "arg": 1000}}',
                 0,
                 False,
+                message_expiry_interval=None,
             )
         ]
     )
@@ -156,6 +158,7 @@ async def test_service_discharge(hass, mqtt_mock):
                 '{"transId": "00000000-0000-0000-0000-000000000001", "cmd": {"name": "discharge", "arg": 2000}}',
                 0,
                 False,
+                message_expiry_interval=None,
             )
         ]
     )
@@ -187,6 +190,7 @@ async def test_service_discharge_default_power(hass, mqtt_mock):
                 '{"transId": "00000000-0000-0000-0000-000000000001", "cmd": {"name": "discharge", "arg": 1000}}',
                 0,
                 False,
+                message_expiry_interval=None,
             )
         ]
     )
@@ -218,6 +222,7 @@ async def test_service_autocharge(hass, mqtt_mock):
                 '{"transId": "00000000-0000-0000-0000-000000000001", "cmd": {"name": "auto"}}',
                 0,
                 False,
+                message_expiry_interval=None,
             )
         ]
     )
@@ -345,6 +350,7 @@ async def test_multiple_configs_correct_prefix_is_used(hass, mqtt_mock):
                 '{"transId": "00000000-0000-0000-0000-000000000001", "cmd": {"name": "auto"}}',
                 0,
                 False,
+                message_expiry_interval=None,
             )
         ]
     )

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2381,6 +2381,7 @@ async def test_extapi_version_request(hass, mqtt_mock):
         '{"transId": "00000000-0000-0000-0000-000000000001", "cmd": {"name": "extapiversion"}}',
         0,
         False,
+        message_expiry_interval=None,
     )
 
 


### PR DESCRIPTION
## Problem

Dependabot has not opened a `pytest-homeassistant-custom-component` PR in over a year — 158 releases missed (0.13.190 -> 0.13.348).

Root cause is a pin deadlock. `requirements.dev.txt` pinned `homeassistant==2024.12.0`, and phacc pins Home Assistant **exactly** (`0.13.190` -> `homeassistant==2024.12.0`). Every newer phacc needs a newer HA, so bumping phacc alone is unresolvable; bumping HA alone conflicts with the phacc pin. Dependabot's pip updater does not do coordinated multi-package updates on plain `requirements*.txt`, so it silently skipped the update. Other pip deps kept updating fine, which is why this went unnoticed.

## Changes

| File | Change |
|---|---|
| `requirements.dev.txt` | dropped `homeassistant==2024.12.0` — redundant, phacc pins it transitively |
| `requirements.test.txt` | phacc `0.13.190` -> `0.13.348` |
| `pyproject.toml` | `requires-python = ">=3.14, <4.0"` |
| `.github/workflows/pythonpackage.yaml` | CI matrix `3.13` -> `3.14` |
| `.devcontainer/devcontainer.json` | image `python:3.12` -> `python:3.14` |
| `CLAUDE.md` | required Python 3.13+ -> 3.14+ |
| `tests/test_init.py`, `tests/test_sensor.py` | +`message_expiry_interval=None` on 7 mqtt publish assertions |

The phacc bump could not be deferred to Dependabot: HA 2024.12.0 pulls `home-assistant-bluetooth==1.13.0`, which is capped at `<3.14`, so the old pins do not install on Python 3.14 at all.

```
ERROR: Could not find a version that satisfies the requirement home-assistant-bluetooth==1.13.0
```

HA 2026.7.4 requires `>=3.14.2`; `setup-python` with `"3.14"` resolves to the latest patch.

## Test drift

Only one real breakage across 158 releases: HA's MQTT client now passes `message_expiry_interval` to `async_publish`, and the tests asserted exact call args.

## Verification

```
115 passed in 4.17s
Required test coverage of 95.0% reached. Total coverage: 98.00%
```
Run locally on Python 3.14.6 with phacc 0.13.348.

## Notes

- `hacs.json` still declares minimum HA `2024.12.0`. That is the runtime support floor for users, deliberately untouched — bump it separately if old-HA support should be dropped.
- Unverified: whether Dependabot's pip updater has a Python 3.14 runtime yet. Worth checking the Dependabot logs after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SC9rPY7HADvvwCMwSF3ZS